### PR TITLE
Ripley lnj

### DIFF
--- a/Carnap-Book/chapter10.pandoc
+++ b/Carnap-Book/chapter10.pandoc
@@ -1,4 +1,4 @@
-#Truth Tables
+#Chapter 10: Truth Tables
 
 In this chapter, we'll discuss the method of *Truth Tables*, which gives us a
 "negative test" for validity. Derivations show us when an argument form is

--- a/Carnap-Book/chapter11.pandoc
+++ b/Carnap-Book/chapter11.pandoc
@@ -1,4 +1,4 @@
-#The Quantified Language
+#Chapter 11: The Quantified Language
 
 In the previous sections, we've built up a powerful propositional language,
 which we can use to study the logical forms of many different types of

--- a/Carnap-Book/chapter12.pandoc
+++ b/Carnap-Book/chapter12.pandoc
@@ -1,4 +1,4 @@
-#Quantifiers and Derivations
+#Chapter 12: Quantifiers and Derivations
 
 Now that we have added quantifiers to our language, it's time to learn how to
 reason with them. 

--- a/Carnap-Book/chapter2.pandoc
+++ b/Carnap-Book/chapter2.pandoc
@@ -1,4 +1,4 @@
-#Official and Unofficial Notation
+#Chapter 2: Official and Unofficial Notation
 
 Recall, the basic rules for building up grammatical assertions in the simple
 language we've been using so far.

--- a/Carnap-Book/chapter3.pandoc
+++ b/Carnap-Book/chapter3.pandoc
@@ -1,4 +1,4 @@
-#Derivations
+#Chapter 3: Derivations
 
 Suppose we wish to know whether
 the argument 

--- a/Carnap-Book/chapter4.pandoc
+++ b/Carnap-Book/chapter4.pandoc
@@ -1,4 +1,4 @@
-#Conditional Derivations
+#Chapter 4: Conditional Derivations
 
 Direct Derivations are not the only kinds of derivations. There are, in fact,
 two more basic types of derivations we will consider. The first of these is

--- a/Carnap-Book/chapter5.pandoc
+++ b/Carnap-Book/chapter5.pandoc
@@ -1,4 +1,4 @@
-#Nested Derivations
+#Chapter 5: Nested Derivations
 
 Sometimes, a conditional derivation will not be enough to show that a certain
 conditional we want is true. The trouble is that in a conditional derivation,

--- a/Carnap-Book/chapter6.pandoc
+++ b/Carnap-Book/chapter6.pandoc
@@ -1,4 +1,4 @@
-#Indirect Derivations
+#Chapter 6: Indirect Derivations
 
 The last type of derivation that we will consider is an indirect derivation. 
 An indirect derivation is, generally speaking, a derivation used in order to 

--- a/Carnap-Book/chapter7.pandoc
+++ b/Carnap-Book/chapter7.pandoc
@@ -1,4 +1,4 @@
-#Derived Rules
+#Chapter 7: Derived Rules
 
 
 > *As men at first made use of the instruments supplied by nature to

--- a/Carnap-Book/chapter8.pandoc
+++ b/Carnap-Book/chapter8.pandoc
@@ -1,4 +1,4 @@
-#And, Or, If and Only If
+#Chapter 8: And, Or, If and Only If
 
 You may have noticed that the derivations we have constructed so far only use
 the symbols $\rightarrow$ and $\neg$. This keeps things simpler, and gives us a

--- a/Carnap-Book/chapter9.pandoc
+++ b/Carnap-Book/chapter9.pandoc
@@ -1,4 +1,4 @@
-#Advanced Symbolization
+#Chapter 9: Advanced Symbolization
 
 If we want to be able to use our new system of derivations effectively, we
 need to be able to apply them to English language arguments. But if we want to

--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -15,7 +15,6 @@ library
     hs-source-dirs:  ., app
     exposed-modules: Application
                      Foundation
-                     SecureStrings
                      Import
                      Import.NoFoundation
                      Model
@@ -48,6 +47,10 @@ library
                      Filter.Util
                      Util.Database
                      Util.Data
+
+    if !flag(dev) && !flag(library-only)
+        exposed-modules:
+            SecureStrings
 
     if flag(dev) || flag(library-only)
         cpp-options:   -DDEVELOPMENT

--- a/Carnap-Server/Filter/ProofCheckers.hs
+++ b/Carnap-Server/Filter/ProofCheckers.hs
@@ -42,6 +42,8 @@ activate cls extra chunk
     | "GoldfarbAltNDPlus"`elem` cls = exTemplate [("system", "goldfarbAltNDPlus")]
     | "ZachTFL"          `elem` cls = exTemplate [("system", "thomasBolducAndZachTFL"), ("options","render")]
     | "ZachFOL"          `elem` cls = exTemplate [("system", "thomasBolducAndZachFOL"), ("options","render")]
+    | "EbelsDugganTFL"   `elem` cls = exTemplate [("system", "ebelsDugganTFL"), ("guides", "fitch"), ("options", "fonts resize")]
+    | "EbelsDugganFOL"   `elem` cls = exTemplate [("system", "ebelsDugganFOL"), ("guides", "fitch"), ("options", "fonts resize")]
     | "HardegreeSL"      `elem` cls = exTemplate [("system", "hardegreeSL"),  ("options", "render")]
     | "HardegreePL"      `elem` cls = exTemplate [("system", "hardegreePL"),  ("options", "render")]
     | "HardegreeWTL"     `elem` cls = exTemplate [("system", "hardegreeWTL"), ("guides", "montague"), ("options", "render fonts")]
@@ -89,6 +91,8 @@ toPlayground cls extra content
     | "GoldfarbAltNDPlus"`elem` cls = playTemplate [("system", "goldfarbAltNDPlus"),("options","resize")]
     | "ZachTFL"          `elem` cls = playTemplate [("system", "thomasBolducAndZachTFL"), ("options","render")]
     | "ZachFOL"          `elem` cls = playTemplate [("system", "thomasBolducAndZachFOL"), ("options","render")]
+    | "EbelsDugganTFL"   `elem` cls = playTemplate [("system", "ebelsDugganTFL"), ("guides", "fitch"), ("options", "fonts resize")]
+    | "EbelsDugganFOL"   `elem` cls = playTemplate [("system", "ebelsDugganFOL"), ("guides", "fitch"), ("options", "fonts resize")]
     | "HardegreeSL"      `elem` cls = playTemplate [("system", "hardegreeSL"),  ("options", "render")]
     | "HardegreePL"      `elem` cls = playTemplate [("system", "hardegreePL"),  ("options", "render")]
     | "HardegreeWTL"     `elem` cls = playTemplate [("system", "hardegreeWTL"), ("guides", "montague"), ("options", "render fonts")]
@@ -117,4 +121,3 @@ template opts head content = Div ("",["exercise"],[])
         ++ "</div>"
     ]
     where optString = concatMap (\(x,y) -> (" data-carnap-" ++ x ++ "=\"" ++ y ++ "\"")) (toList opts) 
-

--- a/Carnap-Server/Util/Database.hs
+++ b/Carnap-Server/Util/Database.hs
@@ -169,6 +169,6 @@ udByInstructorId id = do l <- runDB $ selectList [UserDataInstructorId ==. Just 
 getProblemQuery uid cid = do asl <- runDB $ map entityKey <$> selectList [AssignmentMetadataCourse ==. cid] []
                              return $ problemQuery uid asl
 
-problemQuery uid asl = [ ProblemSubmissionUserId ==. uid] 
-                            ++ foldr (||.) [ProblemSubmissionSource ==. Book] (map assignmentQuery asl)
-        where assignmentQuery as = [ProblemSubmissionSource ==. Assignment (show as) ]
+problemQuery uid asl = [ProblemSubmissionUserId ==. uid] 
+                    ++ ([ProblemSubmissionSource ==. Book] ||. [ProblemSubmissionSource <-. assignmentList])
+        where assignmentList = map (\x -> Assignment (show x)) asl

--- a/Carnap-Server/templates/instructor.julius
+++ b/Carnap-Server/templates/instructor.julius
@@ -83,7 +83,7 @@ function modalEditDocument (id,desc,tags) {
 function modalEditCourse (id,desc,start,end,points) {
     jQuery.noConflict()
     var sparts = start.split(" ")
-    var eparts = start.split(" ")
+    var eparts = end.split(" ")
     $("#updateCourse input[name=f1]").val(id);
     $("#updateCourse textarea[name=f2]").val(desc);
     if (sparts.length > 0) {$("#updateCourse input[name=f3]").val(sparts[0]);}

--- a/Carnap/Carnap.cabal
+++ b/Carnap/Carnap.cabal
@@ -17,8 +17,6 @@ library
   exposed-modules:     Carnap.Core.Data.Types
                      , Carnap.Core.Data.Optics
                      , Carnap.Core.Data.Classes
-                     -- , Carnap.Core.Examples.ACUI
-                     -- , Carnap.Core.Examples.ToyLanguages
                      , Carnap.Core.Unification.FirstOrder
                      , Carnap.Core.Unification.Unification
                      , Carnap.Core.Unification.ACUI
@@ -44,6 +42,7 @@ library
                      , Carnap.Languages.PurePropositional.Logic.HowardSnyder
                      , Carnap.Languages.PurePropositional.Logic.Hardegree
                      , Carnap.Languages.PurePropositional.Logic.ThomasBolducAndZach
+                     , Carnap.Languages.PurePropositional.Logic.EbelsDuggan
                      , Carnap.Languages.PurePropositional.Logic.Tomassi
                      , Carnap.Languages.ModalPropositional.Syntax
                      , Carnap.Languages.ModalPropositional.Parser
@@ -65,6 +64,7 @@ library
                      , Carnap.Languages.PureFirstOrder.Logic.Carnap
                      , Carnap.Languages.PureFirstOrder.Logic.KalishAndMontague
                      , Carnap.Languages.PureFirstOrder.Logic.ThomasBolducAndZach
+                     , Carnap.Languages.PureFirstOrder.Logic.EbelsDuggan
                      , Carnap.Languages.PureFirstOrder.Logic.BergmannMoorAndNelson
                      , Carnap.Languages.PureFirstOrder.Logic.IchikawaJenkins
                      , Carnap.Languages.PureFirstOrder.Logic.Hausman

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser.hs
@@ -2,7 +2,7 @@ module Carnap.Calculi.NaturalDeduction.Parser
     ( toProofTreeStructuredFitch, toProofTreeHardegree, toProofTreeMontague, toProofTreeLemmon
     , toProofTreeFitch, toDeductionMontague, toCommentedDeductionFitch
     , toDeductionFitch, toDeductionFitchAlt, toDeductionHardegree, toDeductionLemmon
-    , toDeductionLemmonAlt, toDeductionLemmonTomassi 
+    , toDeductionLemmonAlt, toDeductionLemmonTomassi, toDeductionLemmonImplicit
     ) where
 
 import Carnap.Calculi.NaturalDeduction.Parser.Montague

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/Lemmon.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/Lemmon.hs
@@ -53,13 +53,13 @@ lemlineAlt r = do (dis,deps,annote) <- lookAhead $
           cite3 = (,,) <$> optionMaybe scope <*> optionMaybe bothCitations <*> annotation
           bothCitations = try (citation `sepEndBy` spaces) <|> citations
 
---lemmon justifications used in Tomassi.
-lemlineTomassi r = do indicated <- parseInts
-                      spaces
-                      rule <- r 0 ""
-                      --XXX: discharge of assumptions is done implicitly,
-                      --rather than explicitly flagged in this system
-                      return ([],indicated,rule)
+
+lemlineImplicit r = do indicated <- parseInts
+                       spaces
+                       rule <- r 0 ""
+                       --XXX: discharge of assumptions is done implicitly,
+                       --rather than explicitly flagged in this system
+                       return ([],indicated,rule)
 
 citation :: Parsec String u Int
 citation = char '(' *> (read <$> many1 digit) <* char ')'
@@ -82,7 +82,11 @@ toDeductionLemmonAlt r f = toDeduction (parseDependentAssertLinePlain r f lemlin
 
 toDeductionLemmonTomassi :: Inference r lex (Form Bool) => (Int -> String -> Parsec String () [r]) -> Parsec String () (FixLang lex a) -> String 
     -> Deduction r lex a
-toDeductionLemmonTomassi r f = toDeduction (parseDependentAssertLineWithNum r f lemlineTomassi)
+toDeductionLemmonTomassi r f = toDeduction (parseDependentAssertLineWithNum r f lemlineImplicit)
+
+toDeductionLemmonImplicit :: Inference r lex (Form Bool) => (Int -> String -> Parsec String () [r]) -> Parsec String () (FixLang lex a) -> String 
+    -> Deduction r lex a
+toDeductionLemmonImplicit r f = toDeduction (parseDependentAssertLinePlain r f lemlineImplicit)
 
 toProofTreeLemmon :: 
     ( Inference r lex sem

--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Logic.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Logic.hs
@@ -22,6 +22,7 @@ import Carnap.Languages.PureFirstOrder.Logic.Carnap
 import Carnap.Languages.PureFirstOrder.Logic.Magnus
 import Carnap.Languages.PureFirstOrder.Logic.KalishAndMontague
 import Carnap.Languages.PureFirstOrder.Logic.ThomasBolducAndZach
+import Carnap.Languages.PureFirstOrder.Logic.EbelsDuggan
 import Carnap.Languages.PureFirstOrder.Logic.BergmannMoorAndNelson
 import Carnap.Languages.PureFirstOrder.Logic.Hausman
 import Carnap.Languages.PureFirstOrder.Logic.HowardSnyder
@@ -36,6 +37,7 @@ ofFOLSys f sys | sys == "firstOrder"                = Just $ f folCalc
                | sys == "montagueQC"                = Just $ f montagueQCCalc 
                | sys == "magnusQL"                  = Just $ f magnusQLCalc 
                | sys == "thomasBolducAndZachFOL"    = Just $ f thomasBolducAndZachFOLCalc 
+               | sys == "ebelsDugganFOL"            = Just $ f ebelsDugganFOLCalc
                | sys == "LogicBookPD"               = Just $ f logicBookPDCalc 
                | sys == "LogicBookPDPlus"           = Just $ f logicBookPDPlusCalc 
                | sys == "hausmanPL"                 = Just $ f hausmanPLCalc 

--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/EbelsDuggan.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/EbelsDuggan.hs
@@ -1,0 +1,75 @@
+{-#LANGUAGE  FlexibleContexts,  FlexibleInstances, MultiParamTypeClasses #-}
+module Carnap.Languages.PureFirstOrder.Logic.EbelsDuggan (ebelsDugganFOLCalc,parseEbelsDugganFOL) where
+
+import Data.Map as M (lookup, Map,empty)
+import Text.Parsec
+import Carnap.Core.Data.Types (Form)
+import Carnap.Languages.PureFirstOrder.Syntax
+import Carnap.Languages.PureFirstOrder.Parser
+import qualified Carnap.Languages.PurePropositional.Logic as P
+import Carnap.Calculi.NaturalDeduction.Syntax
+import Carnap.Calculi.NaturalDeduction.Parser
+import Carnap.Calculi.NaturalDeduction.Checker (hoProcessLineFitchMemo, hoProcessLineFitch)
+import Carnap.Languages.ClassicalSequent.Syntax
+import Carnap.Languages.ClassicalSequent.Parser
+import Carnap.Languages.Util.LanguageClasses
+import Carnap.Languages.Util.GenericConstructors
+import Carnap.Languages.PureFirstOrder.Logic.Rules
+import Carnap.Languages.PurePropositional.Logic.Rules (premConstraint,axiom)
+import Carnap.Languages.PureFirstOrder.Logic.ThomasBolducAndZach
+import Carnap.Languages.PurePropositional.Logic.EbelsDuggan
+
+data EbelsDugganFOL = EDTFL P.EbelsDugganTFL | TBZFOL ThomasBolducAndZachFOL | EQS | EQT
+
+instance Show EbelsDugganFOL where
+        show (EDTFL x) = show x
+        show (TBZFOL x) = show x
+        show EQS = "=S"
+        show EQT = "=T"
+
+instance Inference EbelsDugganFOL PureLexiconFOL (Form Bool) where
+
+         ruleOf (TBZFOL x) = ruleOf x
+         ruleOf r@(EDTFL x) = premisesOf r ∴ conclusionOf r
+         ruleOf EQS = eqSymmetry
+         ruleOf EQT = eqTransitivity
+
+         premisesOf (EDTFL x) = map liftSequent (premisesOf x)
+         premisesOf r = upperSequents (ruleOf r)
+         
+         conclusionOf (EDTFL x) = liftSequent (conclusionOf x)
+         conclusionOf r = lowerSequent (ruleOf r)
+
+         indirectInference (EDTFL x) = indirectInference x
+         indirectInference (TBZFOL x) = indirectInference x
+         indirectInference x = Nothing
+
+         restriction (TBZFOL x) = restriction x
+         restriction _     = Nothing
+
+         isAssumption (EDTFL x) = isAssumption x
+         isAssumption (TBZFOL x) = isAssumption x
+         isAssumption _ = False
+
+         isPremise (EDTFL x) = isPremise x
+         isPremise (TBZFOL x) = isPremise x
+         isPremise _ = False
+
+parseEbelsDugganFOL rtc = try (map TBZFOL <$> parseThomasBolducAndZachFOL rtc) 
+                      <|> try (map EDTFL <$> parseEbelsDugganTFL (RuntimeNaturalDeductionConfig mempty mempty))
+                      <|> do r <- choice (map (try . string) ["=S", "=T"])
+                             return $ case r of "=S" -> [EQS]
+                                                "=T" -> [EQT]
+
+parseEbelsDugganFOLProof :: RuntimeNaturalDeductionConfig PureLexiconFOL (Form Bool) -> String -> [DeductionLine EbelsDugganFOL PureLexiconFOL (Form Bool)]
+parseEbelsDugganFOLProof ders = toDeductionFitch (parseEbelsDugganFOL ders) thomasBolducAndZachFOLFormulaParser
+
+ebelsDugganFOLCalc = mkNDCalc
+    { ndRenderer = FitchStyle StandardFitch
+    , ndParseProof = parseEbelsDugganFOLProof
+    , ndProcessLine = hoProcessLineFitch
+    , ndProcessLineMemo = Just hoProcessLineFitchMemo
+    , ndParseSeq = parseSeqOver thomasBolducAndZachFOLFormulaParser
+    , ndParseForm = thomasBolducAndZachFOLFormulaParser
+    , ndNotation = ndNotation P.thomasBolducAndZachTFLCalc
+    }

--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Rules.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Rules.hs
@@ -205,6 +205,11 @@ eqReflexivity = [] ∴ Top :|-: SS (tau `equals` tau)
 eqSymmetry :: FirstOrderEqRule lex b
 eqSymmetry = [GammaV 1 :|-: SS (tau `equals` tau')] ∴ GammaV 1 :|-: SS (tau' `equals` tau)
 
+eqTransitivity :: FirstOrderEqRule lex b
+eqTransitivity = [GammaV 1 :|-: SS (tau `equals` tau')
+                 , GammaV 1 :|-: SS (tau' `equals` tau'')
+                 ] ∴ GammaV 1 :|-: SS (tau `equals` tau'')
+
 eqNegSymmetry :: FirstOrderEqRule lex b
 eqNegSymmetry = [GammaV 1 :|-: SS (lneg $ tau `equals` tau')] ∴ GammaV 1 :|-: SS (lneg $ tau' `equals` tau)
 

--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/ThomasBolducAndZach.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/ThomasBolducAndZach.hs
@@ -1,5 +1,5 @@
 {-#LANGUAGE  FlexibleContexts,  FlexibleInstances, MultiParamTypeClasses #-}
-module Carnap.Languages.PureFirstOrder.Logic.ThomasBolducAndZach (thomasBolducAndZachFOLCalc,parseThomasBolducAndZachFOL) where
+module Carnap.Languages.PureFirstOrder.Logic.ThomasBolducAndZach (thomasBolducAndZachFOLCalc,parseThomasBolducAndZachFOL, ThomasBolducAndZachFOL) where
 
 import Data.Map as M (lookup, Map,empty)
 import Text.Parsec
@@ -56,6 +56,7 @@ instance Inference ThomasBolducAndZachFOL PureLexiconFOL (Form Bool) where
          ruleOf QN3    = quantifierNegation !! 2
          ruleOf QN4    = quantifierNegation !! 3
          ruleOf (Pr _) = axiom
+         ruleOf r@(ThomasBolducAndZachTFL _) = premisesOf r ∴ conclusionOf r
 
          ruleOf IDE1  = leibnizLawVariations !! 0
          ruleOf IDE2  = leibnizLawVariations !! 1

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic.hs
@@ -11,6 +11,7 @@ module Carnap.Languages.PurePropositional.Logic
     , parseMagnusSL, MagnusSL, magnusSLCalc
     , parseMagnusSLPlus, MagnusSLPlus, magnusSLPlusCalc
     , parseThomasBolducAndZachTFL, ThomasBolducAndZachTFL, thomasBolducAndZachTFLCalc
+    , parseEbelsDugganTFL, EbelsDugganTFL, ebelsDugganTFLCalc
     , parseTomassiPL, TomassiPL, tomassiPLCalc
     , parseHardegreeSL, HardegreeSL, hardegreeSLCalc
     , ofPropSys
@@ -28,6 +29,7 @@ import Carnap.Languages.PurePropositional.Logic.HowardSnyder
 import Carnap.Languages.PurePropositional.Logic.KalishAndMontague
 import Carnap.Languages.PurePropositional.Logic.Magnus
 import Carnap.Languages.PurePropositional.Logic.ThomasBolducAndZach
+import Carnap.Languages.PurePropositional.Logic.EbelsDuggan
 import Carnap.Languages.PurePropositional.Logic.Tomassi
 import Carnap.Languages.PurePropositional.Logic.IchikawaJenkins
 
@@ -44,6 +46,7 @@ ofPropSys f sys | sys == "prop"                      = Just $ f propCalc
                 | sys == "magnusSL"                  = Just $ f magnusSLCalc 
                 | sys == "magnusSLPlus"              = Just $ f magnusSLPlusCalc 
                 | sys == "thomasBolducAndZachTFL"    = Just $ f thomasBolducAndZachTFLCalc 
+                | sys == "ebelsDugganTFL"            = Just $ f ebelsDugganTFLCalc 
                 | sys == "tomassiPL"                 = Just $ f tomassiPLCalc
                 | sys == "hardegreeSL"               = Just $ f hardegreeSLCalc 
                 | otherwise                          = Nothing

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/EbelsDuggan.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/EbelsDuggan.hs
@@ -1,0 +1,125 @@
+{-#LANGUAGE FlexibleContexts, FlexibleInstances, MultiParamTypeClasses #-}
+module Carnap.Languages.PurePropositional.Logic.EbelsDuggan 
+    (parseEbelsDugganTFL, EbelsDugganTFL,  ebelsDugganTFLCalc) where
+
+import Data.Map as M (lookup, Map)
+import Text.Parsec
+import Carnap.Core.Data.Types (Form)
+import Carnap.Languages.PurePropositional.Syntax
+import Carnap.Languages.PurePropositional.Parser
+import Carnap.Calculi.NaturalDeduction.Syntax
+import Carnap.Calculi.NaturalDeduction.Parser
+import Carnap.Calculi.NaturalDeduction.Checker
+import Carnap.Languages.ClassicalSequent.Syntax
+import Carnap.Languages.ClassicalSequent.Parser
+import Carnap.Languages.PurePropositional.Logic.Rules
+import Carnap.Languages.PurePropositional.Logic.ThomasBolducAndZach
+
+data EbelsDugganTFL = TBZ ThomasBolducAndZachTFL
+                    | RAA1 | RAA2 | RAA3 | RAA4 
+                    | EFQ | DIL | HS | DNI | AndComm1 | AndComm2 | OrComm1
+                    | OrComm2 | IffComm1 | IffComm2 | MC1 | MC2 | MC3 | MC4 
+                    | BCE1 | BCE2 | NC1 | NC2 | BCT1 | BCT2 | TC | FA
+                    deriving (Eq)
+
+instance Show EbelsDugganTFL where
+         show (TBZ x) = show x
+         show RAA1 = "RAA"
+         show RAA2 = "RAA"
+         show RAA3 = "RAA"
+         show RAA4 = "RAA"
+         show EFQ = "EFQ"
+         show DIL = "DIL"
+         show HS = "HS"
+         show DNI = "DNI"
+         show AndComm1 = "Comm"
+         show AndComm2 = "Comm"
+         show OrComm1 = "Comm"
+         show OrComm2 = "Comm"
+         show IffComm1 = "Comm"
+         show IffComm2 = "Comm"
+         show MC1 = "MC"
+         show MC2 = "MC"
+         show MC3 = "MC"
+         show MC4 = "MC"
+         show BCE1 = "↔ex"
+         show BCE2 = "↔ex"
+         show NC1 = "NC"
+         show NC2 = "NC"
+         show BCT1 = "BCT"
+         show BCT2 = "BCT"
+         show TC = "TC"
+         show FA = "FA"
+
+instance Inference EbelsDugganTFL PurePropLexicon (Form Bool) where
+        ruleOf (TBZ x) = ruleOf x
+        ruleOf RAA1 = constructiveReductioVariations !! 0 
+        ruleOf RAA2 = constructiveReductioVariations !! 1
+        ruleOf RAA3 = constructiveReductioVariations !! 2
+        ruleOf RAA4 = constructiveReductioVariations !! 3
+        ruleOf EFQ = exfalso
+        ruleOf DIL = dilemma
+        ruleOf HS = hypotheticalSyllogism
+        ruleOf DNI = doubleNegationIntroduction
+        ruleOf AndComm1 = andCommutativity !! 0
+        ruleOf AndComm2 = andCommutativity !! 1
+        ruleOf OrComm1 = orCommutativity !! 0
+        ruleOf OrComm2 = orCommutativity !! 1
+        ruleOf IffComm1 = iffCommutativity !! 0
+        ruleOf IffComm2 = iffCommutativity !! 1
+        ruleOf MC1 = materialConditional !! 0
+        ruleOf MC2 = materialConditional !! 1
+        ruleOf MC3 = materialConditional !! 2
+        ruleOf MC4 = materialConditional !! 3
+        ruleOf BCE1 = biconditionalExchange !! 0
+        ruleOf BCE2 = biconditionalExchange !! 1
+        ruleOf NC1 = negatedConditional !! 0
+        ruleOf NC2 = negatedConditional !! 1
+        ruleOf BCT1 = biconditionalPonensVariations !! 0
+        ruleOf BCT2 = biconditionalPonensVariations !! 1
+        ruleOf TC = materialConditionalVariations !! 0
+        ruleOf FA = materialConditionalVariations !! 1
+
+        indirectInference (TBZ x) = indirectInference x
+        indirectInference x
+             | x `elem` [RAA1, RAA2, RAA3, RAA4] = Just doubleProof
+             | otherwise = Nothing
+
+        isAssumption (TBZ x) = isAssumption x
+        isAssumption _  = False
+
+        isPremise (TBZ x) = isPremise x
+        isPremise _  = False
+
+        restriction (TBZ x) = restriction x
+        restriction _ = Nothing
+
+parseEbelsDugganTFL :: RuntimeNaturalDeductionConfig PurePropLexicon (Form Bool) -> Parsec String u [EbelsDugganTFL]
+parseEbelsDugganTFL rtc = try ebelsDugganAddition <|>  (map TBZ <$> parseThomasBolducAndZachTFL rtc)
+    where ebelsDugganAddition = do r <- choice (map (try . string) ["RAA", "EFQ", "DIL", "HS", "DNI", "Comm", "MC", "↔ex", "<>E", "<->E", "BCE", "NC", "BCT", "TC", "FA"])
+                                   return $ case r of
+                                          "RAA" -> [RAA1, RAA2, RAA3, RAA4]
+                                          "EFQ" -> [EFQ] 
+                                          "DIL" -> [DIL]
+                                          "HS"  -> [HS]
+                                          "DNI" -> [DNI]
+                                          "Comm" -> [AndComm1, AndComm2, OrComm1, OrComm2, IffComm1, IffComm2]
+                                          "MC" -> [MC1, MC2, MC3, MC4]
+                                          "NC" -> [NC1, NC2]
+                                          "BCT" -> [BCT1, BCT2]
+                                          "TC" -> [TC]
+                                          "FA" -> [FA]
+                                          r | r `elem` ["↔ex", "<>E", "<->E", "BCE"] -> [BCE1, BCE2]
+
+parseEbelsDugganTFLProof :: RuntimeNaturalDeductionConfig PurePropLexicon (Form Bool) -> String -> [DeductionLine EbelsDugganTFL PurePropLexicon (Form Bool)]
+parseEbelsDugganTFLProof rtc = toDeductionFitch (parseEbelsDugganTFL rtc) (purePropFormulaParser thomasBolducZachOpts)
+
+ebelsDugganTFLCalc = mkNDCalc 
+    { ndRenderer = FitchStyle StandardFitch
+    , ndParseProof = parseEbelsDugganTFLProof
+    , ndProcessLine = hoProcessLineFitch
+    , ndProcessLineMemo = Just hoProcessLineFitchMemo
+    , ndParseSeq = parseSeqOver (purePropFormulaParser thomasBolducZachOpts)
+    , ndParseForm = purePropFormulaParser thomasBolducZachOpts
+    , ndNotation = thomasBolducAndZachNotation
+    }

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/Hausman.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/Hausman.hs
@@ -95,7 +95,7 @@ instance Inference HausmanSL PurePropLexicon (Form Bool) where
     ruleOf DeM3 = deMorgansLaws !! 2
     ruleOf DeM4 = deMorgansLaws !! 3
     ruleOf Impl1 = materialConditional !! 0
-    ruleOf Impl2 = materialConditional !! 0
+    ruleOf Impl2 = materialConditional !! 1
     ruleOf Exp1 = exportation !! 0
     ruleOf Exp2 = exportation !! 1
     ruleOf Comm1 = andCommutativity !! 0

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/Magnus.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/Magnus.hs
@@ -227,8 +227,8 @@ instance Inference MagnusSLPlus PurePropLexicon (Form Bool) where
         ruleOf RepMC   = materialConditional !! 1
         ruleOf MCRep2  = materialConditional !! 2
         ruleOf RepMC2  = materialConditional !! 3
-        ruleOf BiExRep = biconditionalExchange !! 1
-        ruleOf RepBiEx = biconditionalExchange !! 2
+        ruleOf BiExRep = biconditionalExchange !! 0
+        ruleOf RepBiEx = biconditionalExchange !! 1
         ruleOf DM1    = deMorgansLaws !! 0
         ruleOf DM2    = deMorgansLaws !! 1
         ruleOf DM3    = deMorgansLaws !! 2

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/Rules.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/Rules.hs
@@ -80,6 +80,11 @@ explosion n = map (\m -> GammaV m :|-: SS (phin m)) [1 .. n]
               ∴ concAnt :|-: SS (phin (n + 1))
     where concAnt = foldr (:+:) Top (map GammaV [1 .. n])
 
+exfalso :: BooleanRule lex b
+exfalso = [ GammaV 1 :|-: SS (phin 1)
+          , GammaV 2 :|-: SS (lneg $ phin 1)
+          ] ∴ GammaV 1 :+: GammaV 2 :|-: SS (phin 2)
+
 identityRule :: BooleanRule lex b
 identityRule = [ GammaV 1 :|-: SS (phin 1) 
                ] ∴ GammaV 1 :|-: SS (phin 1)
@@ -461,6 +466,9 @@ doubleNegation = replace (lneg $ lneg $ phin 1) (phin 1)
 materialConditional :: ReplacementBooleanVariants lex b
 materialConditional = replace (phin 1 .=>. phin 2) (lneg (phin 1) .\/. phin 2)
                    ++ replace (phin 1 .\/. phin 2) (lneg (phin 1) .=>. phin 2)
+
+negatedConditional :: ReplacementBooleanVariants lex b
+negatedConditional = replace (lneg $ phin 1 .=>. phin 2) (phin 1 ./\. (lneg $ phin 2))
 
 contraposition :: ReplacementBooleanVariants lex b
 contraposition = replace (phin 1 .=>. phin 2) (lneg (phin 2) .=>. lneg (phin 1))

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/ThomasBolducAndZach.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/ThomasBolducAndZach.hs
@@ -1,6 +1,6 @@
 {-#LANGUAGE FlexibleContexts, FlexibleInstances, MultiParamTypeClasses #-}
 module Carnap.Languages.PurePropositional.Logic.ThomasBolducAndZach
-    ( parseThomasBolducAndZachTFL, ThomasBolducAndZachTFL,  thomasBolducAndZachTFLCalc) where
+    ( parseThomasBolducAndZachTFL, ThomasBolducAndZachTFL,  thomasBolducAndZachTFLCalc, thomasBolducAndZachNotation) where
 
 import Data.Map as M (lookup, Map)
 import Text.Parsec


### PR DESCRIPTION
A little bit of noise in this, since there have been a few changes on my end. The commit that matters is 802a119.

Also, there's a comment in here about making new rules. Here's some info. The basic pattern is

```
doubleNegationElimination :: BooleanRule lex b
doubleNegationElimination = [ GammaV 1 :|-: SS (lneg $ lneg $ phin 1) 
                            ] ∴ GammaV 1 :|-: SS (phin 1) 
```

which should read as:

```
[ Γ_1 ⊢ ¬¬φ_1 ] 
∴ Γ_1 ⊢ φ_1 
```

basically a list of single-conclusion premise sequents, representing the premises to the rule and their dependencies, and a single-conclusion conclusion sequent with updated dependencies. The syntax for sequents is in Carnap.Languages.ClassicalSequent.Syntax.