### PR TITLE
tweak: explicit rules for explicit lemmon proofs

### DIFF
--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/Ripley.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/Ripley.hs
@@ -43,16 +43,16 @@ instance Inference RipleyLNJ PurePropLexicon (Form Bool) where
         ruleOf ConjIntro    = adjunction
         ruleOf ConjElimL    = simplificationVariations !! 0
         ruleOf ConjElimR    = simplificationVariations !! 1
-        ruleOf CondIntro    = conditionalProofVariations !! 0
-        ruleOf CondIntroVac = conditionalProofVariations !! 1
+        ruleOf CondIntro    = explicitConditionalProofVariations !! 0
+        ruleOf CondIntroVac = explicitConditionalProofVariations !! 1
         ruleOf CondElim     = modusPonens
         ruleOf DisjIntroL   = additionVariations !! 1
         ruleOf DisjIntroR   = additionVariations !! 0
-        ruleOf DisjElim     = proofByCasesVariations !! 0
+        ruleOf DisjElim     = explicitProofByCasesVariations !! 0
         ruleOf FalsumElim   = falsumElimination
         ruleOf As           = axiom        
 
-        globalRestriction (Left ded) n CondIntro = Just (dischargeConstraint n ded (view lhs $ conclusionOf CondElim))
+        globalRestriction (Left ded) n CondIntro = Just (dischargeConstraint n ded (view lhs $ conclusionOf CondIntro))
         globalRestriction (Left ded) n DisjElim = Just (dischargeConstraint n ded (view lhs $ conclusionOf DisjElim))
         globalRestriction _ _ _ = Nothing
 
@@ -71,7 +71,8 @@ parseRipleyLNJ rtc n _ = do
                            , "&I" , "/\\I" , "∧I"
                            , "&EL", "/\\EL", "∧EL"
                            , "&ER", "/\\ER", "∧ER"
-                           , "->I", "→I", "->Iv"
+                           , "->Iv"
+                           , "->I", "→I"
                            , "->E", "→E"
                            , "vIL", "\\/IL", "∨IL"
                            , "vIR", "\\/IR", "∨IR"

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/Rules.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/Rules.hs
@@ -45,7 +45,7 @@ premConstraint (Just prems) sub | theinstance `elem` prems = Nothing
           project = view rhs
 
 dischargeConstraint n ded lhs sub | and (map (`elem` forms) lhs') = Nothing
-                                  | otherwise = Just $ "Some of the stated dependencies in " ++ show lhs' ++ ", are not among the inferred dependencies " ++ show forms ++ "."
+                                  | otherwise = Just $ "Some of the stated dependencies in " ++ show forms ++ ", are not among the inferred dependencies " ++ show lhs' ++ "."
     where lhs' = toListOf concretes . applySub sub $ lhs
           scope = inScope (ded !! (n - 1))
           forms = catMaybes . map (\n -> liftToSequent <$> assertion (ded !! (n - 1))) $ scope
@@ -312,6 +312,10 @@ proofByCasesVariations = [
                 , GammaV 3 :|-: SS (phin 3)
                 ] ∴ GammaV 1 :+: GammaV 2 :+: GammaV 3 :|-: SS (phin 3)
             ]
+
+explicitProofByCasesVariations :: BooleanRuleVariants lex b
+explicitProofByCasesVariations = map addExplic proofByCasesVariations
+    where addExplic (SequentRule upper lower) = SequentRule (upper ++ [SA (phin 1) :|-: SS (phin 1), SA (phin 2) :|-: SS (phin 2)]) lower
 
 tertiumNonDaturVariations :: BooleanRuleVariants lex b
 tertiumNonDaturVariations = [


### PR DESCRIPTION
The explicit rule variants are needed since, when Carnap checks the inference, it treats the discharged assumptions as part of the inference scheme. (This was just the easiest way to make sure that the discharged assumptions match up appropriately with the other cited lines).