### PR TITLE
Fix for over-contraction issue

### DIFF
--- a/Carnap-Client/Carnap-Client.cabal
+++ b/Carnap-Client/Carnap-Client.cabal
@@ -22,6 +22,7 @@ library
                          , parsec
                          , text
                          , bytestring
+                         , containers
                          , Carnap
 
   else 
@@ -30,6 +31,7 @@ library
                          , parsec
                          , text
                          , bytestring
+                         , containers
                          , Carnap
 
   default-language:    Haskell2010

--- a/Carnap-Client/src/Carnap/GHCJS/SharedTypes.hs
+++ b/Carnap-Client/src/Carnap/GHCJS/SharedTypes.hs
@@ -6,6 +6,7 @@ module Carnap.GHCJS.SharedTypes (
 
 import Prelude
 import Data.Aeson (ToJSON(..), FromJSON(..), Value(..), object, (.=), (.:), decodeStrict)
+import Data.Tree (Tree)
 import Text.Read
 import Data.Text (Text)
 import Data.ByteString (ByteString)
@@ -26,7 +27,7 @@ instance ToJSON ProblemSource
 
 instance FromJSON ProblemSource
 
-data ProblemType = Derivation | TruthTable | Translation | SyntaxCheck | CounterModel | Qualitative
+data ProblemType = Derivation | TruthTable | Translation | SyntaxCheck | CounterModel | Qualitative | SequentCalc
     deriving (Show, Read, Eq, Generic)
 
 instance ToJSON ProblemType
@@ -41,6 +42,7 @@ type CounterModelFields = [(String,String)]
 
 data ProblemData = DerivationData Text Text 
                  | DerivationDataOpts Text Text Options
+                 | SequentCalcData Text (Tree (String,String)) Options
                  | TruthTableData Text TruthTable
                  | TruthTableDataOpts Text TruthTable Options
                  | TranslationData Text Text

--- a/Carnap-GHCJS/AllActions/Main.hs
+++ b/Carnap-GHCJS/AllActions/Main.hs
@@ -6,6 +6,7 @@ import Carnap.GHCJS.Action.Translate
 import Carnap.GHCJS.Action.TruthTable
 import Carnap.GHCJS.Action.CounterModel
 import Carnap.GHCJS.Action.QualitativeProblem
+import Carnap.GHCJS.Action.SequentCheck
 import Carnap.GHCJS.Action.AcceptJSON
 
 main :: IO ()
@@ -15,4 +16,5 @@ main = do syntaxCheckAction
           truthTableAction
           counterModelAction
           qualitativeProblemAction
+          sequentCheckAction
           acceptJSONAction

--- a/Carnap-GHCJS/Carnap-GHCJS.cabal
+++ b/Carnap-GHCJS/Carnap-GHCJS.cabal
@@ -22,6 +22,7 @@ library
                      , Carnap.GHCJS.Action.TruthTable
                      , Carnap.GHCJS.Action.CounterModel
                      , Carnap.GHCJS.Action.QualitativeProblem
+                     , Carnap.GHCJS.Action.SequentCheck
                      , Carnap.GHCJS.Action.AcceptJSON
   if impl(ghcjs)
       build-depends:       base >= 4.7 && < 5

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/AcceptJSON.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/AcceptJSON.hs
@@ -62,7 +62,6 @@ checkJSON v = do let Success (s,d,c,p) = parse parseReply v
                                   Nothing ->  replyObject False "" fb ""
                         (_,Left e) -> return $ replyObject False "" nilson "couldn't parse conclusion"
 
-
     where serialize (Left e) = Left e
           serialize (Right s) = Right $ show s
           nilson = toJSON ("" :: String)
@@ -158,6 +157,7 @@ instance (Schematizable (FixLang lex), Schematizable (ClassicalSequentOver lex))
 #ifdef __GHCJS__
 
 foreign import javascript unsafe "acceptJSONCallback_ = $1" initializeCallbackJS :: Callback (payload -> succ -> IO ()) -> IO ()
+--TODO: unify with other callback code in SequentCheck
 
 foreign import javascript unsafe "$1($2);" simpleCall :: JSVal -> JSVal -> IO ()
 

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/ProofCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/ProofCheck.hs
@@ -116,7 +116,7 @@ activateChecker drs w (Just iog@(IOGoal i o g _ opts)) -- TODO: need to update n
                   memo <- newIORef mempty
                   mtref <- newIORef Nothing
                   mpd <- if render options then Just <$> makeDisplay else return Nothing
-                  mseq <- if directed options then parseGoal options calc else return Nothing
+                  mseq <- if directed options then parseGoal calc else return Nothing
                   let theChecker = checker calc drs mseq mtref mpd memo
                       checkSeq = threadedCheck options theChecker
                       saveProblem l s = Button {label = "Submit" , action = submitDer opts theChecker l g s}
@@ -133,14 +133,14 @@ activateChecker drs w (Just iog@(IOGoal i o g _ opts)) -- TODO: need to update n
                                        Left e -> error "couldn't parse goal"
                                        Right seq -> seq
 
-              parseGoal options calc = do let seqParse = ndParseSeq calc
-                                              (Just seqstring) = M.lookup "goal" opts 
-                                              --XXX: the directed option is set by the existence of a goal, so this match can't fail.
-                                          case parse seqParse "" seqstring of
-                                              Left e -> do setInnerHTML g (Just $ "Couldn't Parse This Goal:" ++ seqstring)
-                                                           error "couldn't parse goal"
-                                              Right seq -> do setInnerHTML g (Just $ ndNotation calc $ show seq)
-                                                              return $ Just seq
+              parseGoal calc = do let seqParse = ndParseSeq calc
+                                      (Just seqstring) = M.lookup "goal" opts 
+                                      --XXX: the directed option is set by the existence of a goal, so this match can't fail.
+                                  case parse seqParse "" seqstring of
+                                      Left e -> do setInnerHTML g (Just $ "Couldn't Parse This Goal:" ++ seqstring)
+                                                   error "couldn't parse goal"
+                                      Right seq -> do setInnerHTML g (Just $ ndNotation calc $ show seq)
+                                                      return $ Just seq
                                                               
               makeDisplay = do (Just pd) <- createElement w (Just "div")
                                setAttribute pd "class" "proofDisplay"

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
@@ -130,9 +130,12 @@ checkOnChange threadRef calc changed = do
         t' <- forkIO $ do
             threadDelay 500000
             changedParent <- ascendTree changed --may need to update the parent of the changed node if it exists
-            Just changedVal <- toCleanVal changedParent
-            theInfo <- checkSequent calc (Just 3) changedVal 
-            decorate changedParent theInfo
+            Just changedVal <- toCleanVal changed
+            Just changedParentVal <- toCleanVal changedParent
+            theParentInfo <- checkSequent calc (Just 1) changedParentVal 
+            theInfo <- checkSequent calc (Just 1) changedVal 
+            decorate changedParent theParentInfo
+            decorate changed theInfo
             return ()
         writeIORef threadRef (Just t')
 

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
@@ -74,4 +74,3 @@ toInfo (Node Correct ss) = object [ "info" .= ("Correct" :: String), "class" .= 
 toInfo (Node (Feedback e) ss) = object [ "info" .= e, "class" .= ("feedback" :: String), "forest" .= map toInfo ss]
 toInfo (Node Waiting ss) = object [ "info" .= ("Waiting for parsing to be completed." :: String), "class" .= ("waiting" :: String), "forest" .= map toInfo ss]
 toInfo (Node (ParseErrorMsg e) ss) = object [ "info" .= e, "class" .= ("parse-error" :: String), "forest" .= map toInfo ss]
-

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
@@ -19,6 +19,7 @@ import GHCJS.DOM
 import Carnap.Core.Data.Types
 import Carnap.Core.Data.Optics
 import Carnap.Calculi.Tableau.Data
+import Carnap.Calculi.Tableau.Checker
 import Carnap.Languages.ClassicalSequent.Syntax
 import Carnap.Languages.ClassicalSequent.Parser
 import Carnap.Languages.PurePropositional.Logic.IchikawaJenkins
@@ -33,7 +34,7 @@ checkSequent :: Value -> IO Value
 checkSequent v = do let Success t = parse parseReply v
                     case toTableau ichkawaJenkinsSLTableauCalc t of 
                         Left feedback -> return . toInfo $ feedback
-                        Right tab -> return . toInfo $ fmap (Feedback . show . tableauNodeSeq) tab
+                        Right tab -> return . toInfo . validateTree $ tab
 
 parseReply :: Value -> Parser (Tree (String,String))
 parseReply = withObject "Sequent Tableau" $ \o -> do

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
@@ -146,7 +146,7 @@ checkSequent :: ( ReLex lex
                 ) => TableauCalc lex sem rule -> Maybe Int -> Value -> IO Value
 checkSequent calc depth v = case parse parseTreeJSON v of
                                Success t -> case toTableau calc (trimTree depth t) of 
-                                   Left feedback -> return . toInfo $ feedback
+                                   Left feedback -> return . toInfo . trimTree ((\x -> x - 1) <$> depth)  $ feedback
                                    Right tab -> return . toInfo . trimTree ((\x -> x - 1) <$> depth) . validateTree $ tab
                                Error s -> do print (show v)
                                              error s

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
@@ -51,6 +51,9 @@ activateChecker :: Document -> Maybe (Element, Element, Map String String) -> IO
 activateChecker _ Nothing  = return ()
 activateChecker w (Just (i, o, opts))
         | sys == "propLK"  = setupWith gentzenPropLKCalc
+        | sys == "propLJ"  = setupWith gentzenPropLJCalc
+        | sys == "foLK"    = setupWith gentzenFOLKCalc
+        | sys == "foLJ"    = setupWith gentzenFOLJCalc
         where sys = case M.lookup "system" opts of
                         Just s -> s
                         Nothing -> "propLK"

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
@@ -1,11 +1,14 @@
-{-# LANGUAGE OverloadedStrings, CPP, JavaScriptFFI #-}
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, CPP, JavaScriptFFI #-}
 module Carnap.GHCJS.Action.SequentCheck (sequentCheckAction) where
 
 import Data.Tree
+import Data.Either
 import Data.Aeson
+import Data.Typeable (Typeable)
 import Data.Aeson.Types
 import Data.Text.Encoding
 import Data.ByteString.Lazy (fromStrict)
+import qualified Text.Parsec as P (parse) 
 #ifdef __GHCJS__
 import GHCJS.Types
 import GHCJS.Foreign
@@ -13,6 +16,12 @@ import GHCJS.Foreign.Callback
 import GHCJS.Marshal
 #endif
 import GHCJS.DOM
+import Carnap.Core.Data.Types
+import Carnap.Core.Data.Optics
+import Carnap.Calculi.Tableau.Data
+import Carnap.Languages.ClassicalSequent.Syntax
+import Carnap.Languages.ClassicalSequent.Parser
+import Carnap.Languages.PurePropositional.Logic.IchikawaJenkins
 
 sequentCheckAction ::  IO ()
 sequentCheckAction = runWebGUI $ \w -> 
@@ -22,8 +31,9 @@ sequentCheckAction = runWebGUI $ \w ->
 
 checkSequent :: Value -> IO Value
 checkSequent v = do let Success t = parse parseReply v
-                    print . toInfo . fmap fst $ t
-                    return . toInfo . fmap fst $ t
+                    case toTableau ichkawaJenkinsSLTableauCalc t of 
+                        Left feedback -> return . toInfo $ feedback
+                        Right tab -> return . toInfo $ fmap (Feedback . show . tableauNodeSeq) tab
 
 parseReply :: Value -> Parser (Tree (String,String))
 parseReply = withObject "Sequent Tableau" $ \o -> do
@@ -32,8 +42,27 @@ parseReply = withObject "Sequent Tableau" $ \o -> do
     theforest <- o .: "forest" :: Parser [Value]
     Node (thelabel,therule) <$>  mapM parseReply theforest
 
-toInfo :: Tree String -> Value
-toInfo (Node s ss) = object [ "info" .= s, "forest" .= map toInfo ss]
+toTableau :: ( Typeable sem
+             , ReLex lex
+             , Sequentable lex
+             ) => TableauCalc lex sem rule -> Tree (String,String) -> Either TreeFeedback (Tableau lex sem rule)
+toTableau calc (Node (l,r) f) 
+    | all isRight parsedForest && isRight newNode = Node <$> newNode <*> sequence parsedForest
+    | isRight newNode = Left $ Node Correct (map cleanTree parsedForest)
+    | Left n <- newNode = Left n
+    where parsedLabel = P.parse (parseSeqOver (tbParseForm calc)) "" l
+          parsedRule = if r == "" then pure Nothing else P.parse (Just <$> tbParseRule calc) "" r
+          easyTarget = P.parse (tbParseForm calc) "" (takeWhile (not . (`elem` [',',':'])) l) --XXX: just a placeholder for proper target
+          parsedForest = map (toTableau calc) f
+          cleanTree (Left fs) = fs
+          cleanTree (Right fs) = fmap (const Correct) fs
+          newNode = case TableauNode <$> parsedLabel <*> easyTarget <*> parsedRule of
+                        Right n -> Right n
+                        Left e -> Left (Node (Feedback (show e)) (map cleanTree parsedForest))
+
+toInfo :: TreeFeedback -> Value
+toInfo (Node Correct ss) = object [ "info" .= ("Correct" :: String), "forest" .= map toInfo ss]
+toInfo (Node (Feedback e) ss) = object [ "info" .= e, "forest" .= map toInfo ss]
 
 #ifdef __GHCJS__
 

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
@@ -136,6 +136,9 @@ checkOnChange threadRef calc changed = do
             theInfo <- checkSequent calc (Just 1) changedVal 
             decorate changedParent theParentInfo
             decorate changed theInfo
+            --XXX: we do these separately in order to keep a parse error in
+            --either of the inferences from causing trouble in the
+            --other inference.
             return ()
         writeIORef threadRef (Just t')
 

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
@@ -22,8 +22,8 @@ sequentCheckAction = runWebGUI $ \w ->
 
 checkSequent :: Value -> IO Value
 checkSequent v = do let Success t = parse parseReply v
-                    print t
-                    return v
+                    print . toInfo . fmap fst $ t
+                    return . toInfo . fmap fst $ t
 
 parseReply :: Value -> Parser (Tree (String,String))
 parseReply = withObject "Sequent Tableau" $ \o -> do
@@ -32,9 +32,12 @@ parseReply = withObject "Sequent Tableau" $ \o -> do
     theforest <- o .: "forest" :: Parser [Value]
     Node (thelabel,therule) <$>  mapM parseReply theforest
 
+toInfo :: Tree String -> Value
+toInfo (Node s ss) = object [ "info" .= s, "forest" .= map toInfo ss]
+
 #ifdef __GHCJS__
 
-foreign import javascript unsafe "checkSequent_ = $2" initializeCallbackJS :: Callback (payload -> succ -> IO ()) -> IO ()
+foreign import javascript unsafe "checkSequent_ = $1" initializeCallbackJS :: Callback (payload -> succ -> IO ()) -> IO ()
 --TODO: unify with other callback code in SequentCheck
 
 foreign import javascript unsafe "$1($2);" simpleCall :: JSVal -> JSVal -> IO ()

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
@@ -69,6 +69,13 @@ toTableau calc (Node (l,r) f)
                         Right n -> Right n
                         Left e -> Left (Node (ParseErrorMsg (show e)) (map cleanTree parsedForest))
 
+fromInfo :: Value -> Parser Bool
+fromInfo = withObject "Info Tree" $ \o -> do
+    theInfo <- o .: "info" :: Parser String
+    theForest <- o .: "forest" :: Parser [Value]
+    processedForest <- mapM fromInfo theForest
+    return $ theInfo == "Correct" && and processedForest
+
 toInfo :: TreeFeedback -> Value
 toInfo (Node Correct ss) = object [ "info" .= ("Correct" :: String), "class" .= ("correct" :: String), "forest" .= map toInfo ss]
 toInfo (Node (Feedback e) ss) = object [ "info" .= e, "class" .= ("feedback" :: String), "forest" .= map toInfo ss]

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
@@ -41,7 +41,9 @@ parseReply = withObject "Sequent Tableau" $ \o -> do
     thelabel   <- o .: "label" :: Parser String
     therule <- o .: "rule" :: Parser String
     theforest <- o .: "forest" :: Parser [Value]
-    Node (thelabel,therule) <$>  mapM parseReply theforest
+    filteredForest <- filter (\(Node (x,y) _) -> x /= "") <$> mapM parseReply theforest
+    --ignore empty nodes
+    return $ Node (thelabel,therule) filteredForest
 
 toTableau :: ( Typeable sem
              , ReLex lex

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
@@ -88,6 +88,15 @@ activateChecker w (Just (i, o, opts))
                          appendChild par (Just bw)
                          return ()
                      _ -> return ()
+                  initialCheck <- newListener $ liftIO $  do 
+                                    forkIO $ do
+                                        threadDelay 500000
+                                        mr <- toCleanVal root
+                                        case mr of
+                                            Just r -> checkSequent calc Nothing r >>= decorate root
+                                            Nothing -> return ()
+                                    return ()
+                  addListener i initialize initialCheck False --initial check in case we preload a tableau
                   root `onChange` checkOnChange threadRef calc 
 
               parseGoal calc = do 

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
@@ -21,19 +21,27 @@ import Carnap.Languages.ClassicalSequent.Syntax
 import Carnap.Languages.ClassicalSequent.Parser
 import Carnap.Languages.PurePropositional.Logic.IchikawaJenkins
 import Carnap.Languages.PurePropositional.Logic.Gentzen
+import Carnap.Languages.PureFirstOrder.Logic.Gentzen
 
 sequentCheckAction ::  IO ()
 sequentCheckAction = runWebGUI $ \w -> 
             do (Just dom) <- webViewGetDomDocument w
                initCallbackObj
-               initializeCallback "checkPropSequent" checkSequent
+               initializeCallback "checkPropSequent" checkPropSequent
+               initializeCallback "checkFOLSequent" checkFOLSequent
                return ()
 
-checkSequent :: Value -> IO Value
-checkSequent v = do let Success t = parse parseReply v
-                    case toTableau gentzenPropLKCalc t of 
-                        Left feedback -> return . toInfo $ feedback
-                        Right tab -> return . toInfo . validateTree $ tab
+checkPropSequent :: Value -> IO Value
+checkPropSequent v = do let Success t = parse parseReply v
+                        case toTableau gentzenPropLKCalc t of 
+                            Left feedback -> return . toInfo $ feedback
+                            Right tab -> return . toInfo . validateTree $ tab
+
+checkFOLSequent :: Value -> IO Value
+checkFOLSequent v = do let Success t = parse parseReply v
+                       case toTableau gentzenFOLKCalc t of 
+                           Left feedback -> return . toInfo $ feedback
+                           Right tab -> return . toInfo . validateTree $ tab
 
 parseReply :: Value -> Parser (Tree (String,String))
 parseReply = withObject "Sequent Tableau" $ \o -> do

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/SequentCheck.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE OverloadedStrings, CPP, JavaScriptFFI #-}
+module Carnap.GHCJS.Action.SequentCheck (sequentCheckAction) where
+
+import Data.Tree
+import Data.Aeson
+import Data.Aeson.Types
+import Data.Text.Encoding
+import Data.ByteString.Lazy (fromStrict)
+#ifdef __GHCJS__
+import GHCJS.Types
+import GHCJS.Foreign
+import GHCJS.Foreign.Callback
+import GHCJS.Marshal
+#endif
+import GHCJS.DOM
+
+sequentCheckAction ::  IO ()
+sequentCheckAction = runWebGUI $ \w -> 
+            do (Just dom) <- webViewGetDomDocument w
+               initializeCallback checkSequent
+               return ()
+
+checkSequent :: Value -> IO Value
+checkSequent v = do let Success t = parse parseReply v
+                    print t
+                    return v
+
+parseReply :: Value -> Parser (Tree (String,String))
+parseReply = withObject "Sequent Tableau" $ \o -> do
+    thelabel   <- o .: "label" :: Parser String
+    therule <- o .: "rule" :: Parser String
+    theforest <- o .: "forest" :: Parser [Value]
+    Node (thelabel,therule) <$>  mapM parseReply theforest
+
+#ifdef __GHCJS__
+
+foreign import javascript unsafe "checkSequent_ = $2" initializeCallbackJS :: Callback (payload -> succ -> IO ()) -> IO ()
+--TODO: unify with other callback code in SequentCheck
+
+foreign import javascript unsafe "$1($2);" simpleCall :: JSVal -> JSVal -> IO ()
+
+initializeCallback :: (Value -> IO Value) -> IO ()
+initializeCallback  f = do theCB <- asyncCallback2 (cb f)
+                           initializeCallbackJS theCB
+    where cb f payload succ = do (Just raw) <- fromJSVal payload
+                                 let (Just val) = decode . fromStrict . encodeUtf8 $ raw
+                                 rslt <- f val
+                                 rslt' <- toJSVal rslt
+                                 simpleCall succ rslt'
+
+#else
+
+initializeCallback :: (Value -> IO Value) -> IO ()
+initializeCallback = undefined
+
+#endif

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Widget/RenderDeduction.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Widget/RenderDeduction.hs
@@ -104,7 +104,7 @@ lineBase w calc n mf mrd lineclass =
            return (theWrapper,theLine,theForm,theRule)
 
 renderTreeLemmon w calc = treeToElement asLine asSubproof
-    where asLine (n,DependentAssertLine f r deps dis scope mnum) = 
+    where asLine (n,l@(DependentAssertLine f r deps _ scope mnum)) = 
                 do [theWrapper,lineNum,theForm,theRule,theScope] <- catMaybes <$> mapM (createElement w . Just) ["div","span","span","span","span"]
                    case ndRenderer calc of
                        LemmonStyle TomassiStyle -> 
@@ -123,7 +123,7 @@ renderTreeLemmon w calc = treeToElement asLine asSubproof
                    mapM (appendChild theWrapper. Just) [theScope,lineNum,theForm,theRule]
                    return theWrapper
                    
-                where showdischarged = if dis /= [] then show dis else ""
+                where showdischarged = if discharged l /= [] then show (discharged l) else ""
 
                       showdeps = if deps /= [] then "(" ++ intercalate "," (map renderDep deps) ++ ")" else "" 
 

--- a/Carnap-GHCJS/src/Lib.hs
+++ b/Carnap-GHCJS/src/Lib.hs
@@ -1,19 +1,22 @@
 {-# LANGUAGE RankNTypes, QuasiQuotes, FlexibleContexts, DeriveDataTypeable, CPP, JavaScriptFFI #-}
-module Lib
-    (genericSendJSON, sendJSON, onEnter, onKey, clearInput,
-    getListOfElementsByClass, getListOfElementsByTag, tryParse,
-    treeToElement, genericTreeToUl, treeToUl, genericListToUl, listToUl,
-    formToTree, leaves, adjustFirstMatching, decodeHtml, syncScroll,
-    reloadPage, initElements, loginCheck,errorPopup, genInOutElts,
-    getInOutElts,generateExerciseElts, withLabel, formAndLabel,seqAndLabel,
-    folSeqAndLabel, folFormAndLabel, message, IOGoal(..), updateWithValue,
-    submissionSource, assignmentKey, initialize, initializeCallback, initCallbackObj, toCleanVal, popUpWith, spinnerSVG,
-    doneButton, questionButton, exclaimButton, expandButton, buttonWrapper,
-    maybeNodeListToList, trySubmit, inOpts, unform, rewriteWith ) where
+module Lib (genericSendJSON, sendJSON, onEnter, onKey, clearInput,
+           getListOfElementsByClass, getListOfElementsByTag, tryParse,
+           treeToElement, genericTreeToUl, treeToUl, genericListToUl,
+           listToUl, formToTree, leaves, adjustFirstMatching, decodeHtml,
+           decodeJSON, syncScroll, reloadPage, initElements,
+           loginCheck,errorPopup, genInOutElts,
+           getInOutElts,generateExerciseElts, withLabel,
+           formAndLabel,seqAndLabel, folSeqAndLabel, folFormAndLabel,
+           message, IOGoal(..), updateWithValue, submissionSource,
+           assignmentKey, initialize, initializeCallback, initCallbackObj,
+           toCleanVal, popUpWith, spinnerSVG, doneButton, questionButton,
+           exclaimButton, expandButton, buttonWrapper, maybeNodeListToList,
+           trySubmit, inOpts, unform, rewriteWith ) where
 
 import Data.Aeson
 import Data.Maybe (catMaybes)
 import qualified Data.ByteString.Lazy as BSL
+import Data.Text (pack)
 import Data.Text.Encoding
 import Data.Tree as T
 import Data.IORef (IORef, readIORef)
@@ -307,6 +310,9 @@ popUpWith fd w elt label msg details =
 
 decodeHtml :: (StringLike s, Show s) => s -> s
 decodeHtml = TS.fromTagText . head . parseTags
+
+decodeJSON :: String -> Maybe Value
+decodeJSON = decode . BSL.fromStrict . encodeUtf8 . pack
 
 --------------------------------------------------------
 --1.4 Optics

--- a/Carnap-GHCJS/src/Lib.hs
+++ b/Carnap-GHCJS/src/Lib.hs
@@ -574,4 +574,5 @@ message s = liftIO (alert s)
 
 reloadPage :: IO ()
 reloadPage = Prelude.error "you can't reload the page without the GHCJS FFI"
+
 #endif

--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -38,6 +38,7 @@ library
                      Handler.Document
                      Filter.Randomize
                      Filter.Sidenotes
+                     Filter.Sequent
                      Filter.SynCheckers
                      Filter.ProofCheckers
                      Filter.Translate

--- a/Carnap-Server/Filter/Sequent.hs
+++ b/Carnap-Server/Filter/Sequent.hs
@@ -1,32 +1,35 @@
 module Filter.Sequent (makeSequent) where
 
 import Text.Pandoc
+import Filter.Util (splitIt, intoChunks,formatChunk, unlines')
 import Data.Map (fromList, toList, unions)
 import Prelude
 
 makeSequent :: Block -> Block
 makeSequent cb@(CodeBlock (_,classes,extra) contents)
-    | "Sequent" `elem` classes = Div ("",[],[]) $ map (activate classes extra) (lines contents)
+    | "Sequent" `elem` classes = Div ("",[],[]) $ map (activate classes extra) $ intoChunks contents
     | otherwise = cb
 makeSequent x = x
 
-activate cls extra cnt
+activate cls extra chunk
     | "propLK" `elem` cls = template (opts [("system","propLK")])
     | "propLJ" `elem` cls = template (opts [("system","propLJ")])
     | "foLK" `elem` cls = template (opts [("system","foLK")])
     | "foLJ" `elem` cls = template (opts [("system","foLJ")])
     | otherwise = RawBlock "html" "<div>No Matching Sequent Calculus</div>"
-    where numof x = takeWhile (/= ' ') x
-          propof x = dropWhile (== ' ') . dropWhile (/= ' ') $ x
+    where numof = takeWhile (/= ' ')
+          (h:t) = formatChunk chunk
+          propof = dropWhile (== ' ') . dropWhile (/= ' ')
           opts adhoc = unions [fromList extra, fromList fixed, fromList adhoc]
-          fixed = [ ("goal", propof cnt) 
-                  , ("submission", "saveAs:" ++ numof cnt)
+          fixed = [ ("goal", propof h) 
+                  , ("submission", "saveAs:" ++ numof h)
                   , ("type", "sequentchecker")
                   ]
           template opts = Div ("",["exercise"],[])
                             [ Plain 
                                 [Span ("",[],[]) 
-                                    [Str (numof cnt)]
+                                    [Str (numof h)]
                                 ]
-                            , Div ("",[],map (\(x,y) -> ("data-carnap-" ++ x,y)) $ toList opts) []
+                            , Div ("",[],map (\(x,y) -> ("data-carnap-" ++ x,y)) $ toList opts)
+                                            [Plain [Str (unlines' t)]]
                             ]

--- a/Carnap-Server/Filter/Sequent.hs
+++ b/Carnap-Server/Filter/Sequent.hs
@@ -1,0 +1,32 @@
+module Filter.Sequent (makeSequent) where
+
+import Text.Pandoc
+import Data.Map (fromList, toList, unions)
+import Prelude
+
+makeSequent :: Block -> Block
+makeSequent cb@(CodeBlock (_,classes,extra) contents)
+    | "Sequent" `elem` classes = Div ("",[],[]) $ map (activate classes extra) (lines contents)
+    | otherwise = cb
+makeSequent x = x
+
+activate cls extra cnt
+    | "propLK" `elem` cls = template (opts [("system","propLK")])
+    | "propLJ" `elem` cls = template (opts [("system","propLJ")])
+    | "foLK" `elem` cls = template (opts [("system","foLK")])
+    | "foLJ" `elem` cls = template (opts [("system","foLJ")])
+    | otherwise = RawBlock "html" "<div>No Matching Sequent Calculus</div>"
+    where numof x = takeWhile (/= ' ') x
+          propof x = dropWhile (== ' ') . dropWhile (/= ' ') $ x
+          opts adhoc = unions [fromList extra, fromList fixed, fromList adhoc]
+          fixed = [ ("goal", propof cnt) 
+                  , ("submission", "saveAs:" ++ numof cnt)
+                  , ("type", "sequentchecker")
+                  ]
+          template opts = Div ("",["exercise"],[])
+                            [ Plain 
+                                [Span ("",[],[]) 
+                                    [Str (numof cnt)]
+                                ]
+                            , Div ("",[],map (\(x,y) -> ("data-carnap-" ++ x,y)) $ toList opts) []
+                            ]

--- a/Carnap-Server/Handler/Assignment.hs
+++ b/Carnap-Server/Handler/Assignment.hs
@@ -42,10 +42,12 @@ returnAssignment (Entity key val) path = do
                                toWidgetHead $(juliusFile "templates/command.julius")
                                toWidgetHead [julius|var submission_source="#{rawJS source}";|]
                                toWidgetHead [julius|var assignment_key="#{rawJS $ show key}";|]
+                               addScript $ StaticR js_proof_js
                                addScript $ StaticR js_popper_min_js
                                addScript $ StaticR ghcjs_rts_js
                                addScript $ StaticR ghcjs_allactions_lib_js
                                addScript $ StaticR ghcjs_allactions_out_js
+                               addStylesheet $ StaticR css_proof_css
                                addStylesheet $ StaticR css_tree_css
                                addStylesheet $ StaticR css_exercises_css
                                $(widgetFile "document")

--- a/Carnap-Server/Handler/Assignment.hs
+++ b/Carnap-Server/Handler/Assignment.hs
@@ -15,6 +15,7 @@ import Filter.Translate
 import Filter.TruthTables
 import Filter.CounterModelers
 import Filter.Qualitative
+import Filter.Sequent
 
 getAssignmentR :: Text -> Handler Html
 getAssignmentR filename = getAssignment filename >>= uncurry returnAssignment
@@ -67,4 +68,4 @@ fileToHtml salt path = do Markdown md <- markdownFromFile path
                                                              { writerExtensions = carnapPandocExtensions
                                                              , writerWrapText=WrapPreserve } pd'
                               Left e -> return $ Left e
-    where allFilters = (randomizeProblems salt . makeSynCheckers . makeProofChecker . makeTranslate . makeTruthTables . makeCounterModelers . makeQualitativeProblems)
+    where allFilters = (randomizeProblems salt . makeSequent . makeSynCheckers . makeProofChecker . makeTranslate . makeTruthTables . makeCounterModelers . makeQualitativeProblems)

--- a/Carnap-Server/Handler/Document.hs
+++ b/Carnap-Server/Handler/Document.hs
@@ -15,6 +15,7 @@ import Filter.Translate
 import Filter.TruthTables
 import Filter.CounterModelers
 import Filter.Qualitative
+import Filter.Sequent
 
 getDocumentsR :: Handler Html
 getDocumentsR =  runDB (selectList [] []) >>= documentsList "Index of All Documents"
@@ -166,7 +167,7 @@ fileToHtml path = do Markdown md <- markdownFromFile path
                                                          { writerExtensions = carnapPandocExtensions
                                                          , writerWrapText=WrapPreserve } pd'
                          Left e -> return $ Left e
-    where allFilters = (makeSynCheckers . makeProofChecker . makeTranslate . makeTruthTables . makeCounterModelers . makeQualitativeProblems)
+    where allFilters = (makeSequent . makeSynCheckers . makeProofChecker . makeTranslate . makeTruthTables . makeCounterModelers . makeQualitativeProblems)
 
 getUserDir ident = do master <- getYesod
                       return $ (appDataRoot $ appSettings master) </> "documents" </> unpack ident

--- a/Carnap-Server/Handler/Document.hs
+++ b/Carnap-Server/Handler/Document.hs
@@ -122,12 +122,14 @@ getDocumentR ident title = do userdir <- getUserDir ident
                   Right (Right html) -> do
                       defaultLayout $ do
                           toWidgetHead $(juliusFile "templates/command.julius")
+                          addScript $ StaticR js_proof_js
                           addScript $ StaticR js_popper_min_js
                           addScript $ StaticR ghcjs_rts_js
                           addScript $ StaticR ghcjs_allactions_lib_js
                           addScript $ StaticR ghcjs_allactions_out_js
                           addStylesheet $ StaticR css_exercises_css
                           addStylesheet $ StaticR css_tree_css
+                          addStylesheet $ StaticR css_proof_css
                           addStylesheet $ StaticR css_exercises_css
                           $(widgetFile "document")
                           addScript $ StaticR ghcjs_allactions_runmain_js

--- a/Carnap-Server/Handler/Document.hs
+++ b/Carnap-Server/Handler/Document.hs
@@ -128,7 +128,6 @@ getDocumentR ident title = do userdir <- getUserDir ident
                           addScript $ StaticR ghcjs_rts_js
                           addScript $ StaticR ghcjs_allactions_lib_js
                           addScript $ StaticR ghcjs_allactions_out_js
-                          addStylesheet $ StaticR css_exercises_css
                           addStylesheet $ StaticR css_tree_css
                           addStylesheet $ StaticR css_proof_css
                           addStylesheet $ StaticR css_exercises_css

--- a/Carnap-Server/Handler/Info.hs
+++ b/Carnap-Server/Handler/Info.hs
@@ -7,6 +7,7 @@ import Text.Shakespeare.Text
 getInfoR :: Handler Html
 getInfoR = do
     defaultLayout $ do
+        addScript $ StaticR js_proof_js
         addScript $ StaticR js_popper_min_js
         addScript $ StaticR ghcjs_rts_js
         addScript $ StaticR ghcjs_allactions_lib_js
@@ -14,23 +15,28 @@ getInfoR = do
         addScript $ StaticR klement_proofs_js
         addScript $ StaticR klement_syntax_js
         setTitle "Carnap - About"
-        $(widgetFile "infopage")
         addStylesheet $ StaticR css_tree_css
+        addStylesheet $ StaticR css_proof_css
         addStylesheet $ StaticR css_exercises_css
         addStylesheet $ StaticR klement_proofs_css
+        $(widgetFile "infopage")
         -- TODO : split out the stuff specifically relating to exercises
         addScript $ StaticR ghcjs_allactions_runmain_js
 
 -- TODO remove submit option on these.
-proofcheck :: Int -> Text -> Text -> Text -> Text -> HtmlUrl url
-proofcheck n sys opts goal proof = 
+checker :: Int -> Text -> Text -> Text -> Text -> Text -> HtmlUrl url
+checker n thetype sys opts goal proof = 
         [hamlet|
         <div class="exercise">
             <span>example #{show n}
-            <div data-carnap-type="proofchecker" data-carnap-options="#{opts}" data-carnap-system="#{sys}" data-carnap-goal="#{goal}">
+            <div data-carnap-type="#{thetype}" data-carnap-options="#{opts}" data-carnap-system="#{sys}" data-carnap-goal="#{goal}">
                 #{strip proof}
         |]
     where strip = dropWhile (== '\n')
+
+proofcheck n = checker n "proofchecker"
+
+sequentcheck n = checker n "sequentchecker"
 
 -- XXX function that strips text of indentation and line-numbers.
 aristotleTheorem = [st|
@@ -244,3 +250,129 @@ Show P(a) within P(P(a))
  :UD 5
  P(a) within P(P(a)):Def-S 4
 :DD 24|]
+
+sequentDemo = [st|
+ {
+  "label": "AxEy(F(x)/\\G(y)):|-:EyAx(F(x)/\\G(y))",
+  "rule": "RE",
+  "forest": [
+    {
+      "label": "AxEy(F(x)/\\G(y)) :|-: Ax(F(x)/\\G(b)), EyAx(F(x)/\\G(y))",
+      "rule": "LA",
+      "forest": [
+        {
+          "label": "AxEy(F(x)/\\G(y)), Ey(F(a)/\\G(y)) :|-: Ax(F(x)/\\G(b)), EyAx(F(x)/\\G(y))",
+          "rule": "LE",
+          "forest": [
+            {
+              "label": "AxEy(F(x)/\\G(y)), F(a)/\\G(c) :|-: Ax(F(x)/\\G(b)), EyAx(F(x)/\\G(y))",
+              "rule": "L&2",
+              "forest": [
+                {
+                  "label": "G(c), AxEy(F(x)/\\G(y)) :|-: Ax(F(x)/\\G(b)), EyAx(F(x)/\\G(y))",
+                  "rule": "RA",
+                  "forest": [
+                    {
+                      "label": "G(c), AxEy(F(x)/\\G(y)) :|-: F(d)/\\G(b), EyAx(F(x)/\\G(y))",
+                      "rule": "R&",
+                      "forest": [
+                        {
+                          "label": "G(c), AxEy(F(x)/\\G(y)) :|-: F(d), EyAx(F(x)/\\G(y))",
+                          "rule": "LA",
+                          "forest": [
+                            {
+                              "label": "G(c), Ey(F(d)/\\G(y)) :|-: F(d), EyAx(F(x)/\\G(y))",
+                              "rule": "LE",
+                              "forest": [
+                                {
+                                  "label": "G(c), F(d)/\\G(e) :|-: F(d), EyAx(F(x)/\\G(y))",
+                                  "rule": "L&1",
+                                  "forest": [
+                                    {
+                                      "label": "G(c), F(d) :|-: F(d), EyAx(F(x)/\\G(y))",
+                                      "rule": "Ax",
+                                      "forest": [
+                                        {
+                                          "label": "",
+                                          "rule": "",
+                                          "forest": []
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "label": "AxEy(F(x)/\\G(y)), G(c):|-:EyAx(F(x)/\\G(y)), G(b)",
+                          "rule": "RE",
+                          "forest": [
+                            {
+                              "label": "AxEy(F(x)/\\G(y)), G(c):|-:Ax(F(x)/\\G(c)), G(b)",
+                              "rule": "RA",
+                              "forest": [
+                                {
+                                  "label": "G(c), AxEy(F(x)/\\G(y)), :|-:F(a)/\\G(c), G(b)",
+                                  "rule": "LA",
+                                  "forest": [
+                                    {
+                                      "label": "G(c), Ey(F(a)/\\G(y)), :|-:F(a)/\\G(c), G(b)",
+                                      "rule": "LE",
+                                      "forest": [
+                                        {
+                                          "label": "G(c), F(a)/\\G(d) :|-:F(a)/\\G(c), G(b)",
+                                          "rule": "L&1",
+                                          "forest": [
+                                            {
+                                              "label": "G(c), F(a) :|-:F(a)/\\G(c), G(b)",
+                                              "rule": "R&",
+                                              "forest": [
+                                                {
+                                                  "label": "F(a),G(c) :|-:G(c), G(b)",
+                                                  "rule": "Ax",
+                                                  "forest": [
+                                                    {
+                                                      "label": "",
+                                                      "rule": "",
+                                                      "forest": []
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "label": "G(c), F(a) :|-:F(a), G(b)",
+                                                  "rule": "Ax",
+                                                  "forest": [
+                                                    {
+                                                      "label": "",
+                                                      "rule": "",
+                                                      "forest": []
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}             
+|]

--- a/Carnap-Server/Handler/Review.hs
+++ b/Carnap-Server/Handler/Review.hs
@@ -161,6 +161,11 @@ renderProblem (Entity key val) = do
                          data-carnap-problem="#{content}">
                          #{trans}
                 |]
+
+            (SequentCalc, SequentCalcData content tree opts) -> template $
+                [whamlet|
+                    <div>Review of sequent calculus problems is not yet supported
+                |]
             (Translation, TranslationDataOpts content trans opts) -> template $
                 [whamlet|
                     <div data-carnap-type="translate"

--- a/Carnap-Server/Handler/Review.hs
+++ b/Carnap-Server/Handler/Review.hs
@@ -3,6 +3,7 @@ module Handler.Review (getReviewR, putReviewR) where
 import Import
 import Util.Database
 import Data.Map as M (fromList)
+import Data.Tree
 import Data.List (nub)
 import Text.Read (readMaybe)
 import Yesod.Form.Bootstrap3
@@ -40,9 +41,11 @@ getReviewR coursetitle filename =
            let problems = sortBy theSorting unsortedProblems
            defaultLayout $ do
                addScript $ StaticR js_popper_min_js
+               addScript $ StaticR js_proof_js
                addScript $ StaticR ghcjs_rts_js
                addScript $ StaticR ghcjs_allactions_lib_js
                addScript $ StaticR ghcjs_allactions_out_js
+               addStylesheet $ StaticR css_proof_css
                addStylesheet $ StaticR css_exercises_css
                $(widgetFile "review")
                addScript $ StaticR ghcjs_allactions_runmain_js
@@ -164,8 +167,18 @@ renderProblem (Entity key val) = do
 
             (SequentCalc, SequentCalcData content tree opts) -> template $
                 [whamlet|
-                    <div>Review of sequent calculus problems is not yet supported
+                    <div data-carnap-type="sequentchecker"
+                         data-carnap-system="#{sys}"
+                         data-carnap-options="resize"
+                         data-carnap-goal="#{content}"
+                         data-carnap-submission="none">
+                         #{seqJSON tree}
                 |]
+                where sys = case lookup "system" (M.fromList opts) of Just s -> s; Nothing -> "propLK"
+                      seqJSON (Node (l,r) f) = "{\"label\":\"" ++ l 
+                                             ++ "\",\"rule\":\"" ++ r
+                                             ++ "\",\"forest\":[" ++ concatMap seqJSON f
+                                             ++ "]}"
             (Translation, TranslationDataOpts content trans opts) -> template $
                 [whamlet|
                     <div data-carnap-type="translate"

--- a/Carnap-Server/Handler/User.hs
+++ b/Carnap-Server/Handler/User.hs
@@ -78,8 +78,8 @@ getUserR ident = do
                        assignments <- assignmentsOf course textbookproblems asmd asDocs
                        pq <- getProblemQuery uid cid
                        let getSubs typ = map entityVal <$> runDB (selectList ([ProblemSubmissionType ==. typ] ++ pq) [])
-                       subs@[synsubs,transsubs,dersubs,ttsubs,cmsubs,qsubs] <- mapM getSubs [SyntaxCheck,Translation,Derivation,TruthTable,CounterModel,Qualitative]
-                       [syntable,transtable,dertable,tttable,cmtable,qtable] <- mapM (problemsToTable course textbookproblems asmd asDocs) subs
+                       subs@[synsubs,transsubs,dersubs,ttsubs,cmsubs,qsubs,seqsubs] <- mapM getSubs [SyntaxCheck,Translation,Derivation,TruthTable,CounterModel,Qualitative,SequentCalc]
+                       [syntable,transtable,dertable,tttable,cmtable,qtable,seqtable] <- mapM (problemsToTable course textbookproblems asmd asDocs) subs
                        score <- totalScore textbookproblems (concat subs)
                        defaultLayout $ do
                            addScript $ StaticR js_bootstrap_bundle_min_js

--- a/Carnap-Server/Util/Data.hs
+++ b/Carnap-Server/Util/Data.hs
@@ -84,6 +84,7 @@ displayProblemData (TruthTableDataOpts t _ _) = maybe t pack ms
 displayProblemData (TranslationData t _) = t
 displayProblemData (TranslationDataOpts t _ _) = t
 displayProblemData (QualitativeProblemDataOpts t _ _) = t
+displayProblemData (SequentCalcData t _ _) = t
 displayProblemData (ProblemContent t) = maybe t pack ms
     where ms = (show <$> (readMaybe s :: Maybe PureForm))
                `mplus` (intercalate "," . map show <$> (readMaybe s :: Maybe [PureForm]))

--- a/Carnap-Server/static/css/exercises.css
+++ b/Carnap-Server/static/css/exercises.css
@@ -452,6 +452,7 @@ body[data-carnap-type="proofchecker"] .buttonWrapper {
     margin:20px;
 }
 
+[data-carnap-type="sequentchecker"] .buttonWrapper,
 [data-carnap-type="truthtable"] .buttonWrapper,
 [data-carnap-type="countermodeler"] .buttonWrapper,
 [data-carnap-type="qualitative"] .buttonWrapper {

--- a/Carnap-Server/static/css/exercises.css
+++ b/Carnap-Server/static/css/exercises.css
@@ -372,8 +372,7 @@
     width:75px;
 }
 
-[data-carnap-type="proofchecker"] .goal, 
-[data-carnap-type="sequentchecker"] .input
+[data-carnap-type="proofchecker"] .goal
 {
     box-sizing:border-box;
     position:relative;

--- a/Carnap-Server/static/css/exercises.css
+++ b/Carnap-Server/static/css/exercises.css
@@ -372,7 +372,7 @@
     width:75px;
 }
 
-[data-carnap-type="proofchecker"] .goal 
+[data-carnap-type="proofchecker"] .goal, 
 [data-carnap-type="sequentchecker"] .input
 {
     box-sizing:border-box;

--- a/Carnap-Server/static/css/exercises.css
+++ b/Carnap-Server/static/css/exercises.css
@@ -116,6 +116,7 @@
 [data-carnap-type="truthtable"] > .input,
 [data-carnap-type="countermodeler"] > .input,
 [data-carnap-type="qualitative"] > .input,
+[data-carnap-type="sequentchecker"] > .input,
 [data-carnap-type="translate"] > input {
     font-size:14px;
     height:2em;
@@ -133,6 +134,7 @@
 [data-carnap-type="translate"] .output,
 [data-carnap-type="truthtable"] .output,
 [data-carnap-type="countermodeler"] .output,
+[data-carnap-type="sequentchecker"] .output,
 [data-carnap-type="qualitative"] .output { 
     position:relative;
     border:1px solid #A9B7C0;
@@ -215,7 +217,6 @@
 [data-carnap-type="proofchecker"]:not([data-carnap-options~="resize"]) .buttonWrapper{ top:-5px; }
 
 [data-carnap-type="proofchecker"]:not([data-carnap-options~="resize"]) { margin-bottom:0px; }
-
 
 .proofFeedback {
     font-size:10pt;
@@ -371,7 +372,9 @@
     width:75px;
 }
 
-[data-carnap-type="proofchecker"] .goal {
+[data-carnap-type="proofchecker"] .goal 
+[data-carnap-type="sequentchecker"] .input
+{
     box-sizing:border-box;
     position:relative;
     min-height:30px;
@@ -489,7 +492,6 @@ body[data-carnap-type="proofchecker"] .buttonWrapper {
     display: flex;
     align-items:center;
 }
-
 
 [data-carnap-options~="fonts"] textarea,[data-carnap-options~="fonts"] .output, [data-carnap-options~="fonts"] input, [data-carnap-options~="fonts"] .goal {
     text-rendering: optimizeLegibility;

--- a/Carnap-Server/static/css/proof.css
+++ b/Carnap-Server/static/css/proof.css
@@ -72,6 +72,8 @@ input {
     min-width:1em;
 }
 
+.correct input { color: black }
+
 .waiting input { color: gray }
 
 .parse-error input, .feedback input { color: red }

--- a/Carnap-Server/static/css/proof.css
+++ b/Carnap-Server/static/css/proof.css
@@ -1,0 +1,107 @@
+@font-face {
+    font-family:"Fira Logic";
+    src: url("https://cdn.jsdelivr.net/gh/gleachkr/FiraLogic/dist/FiraLogic-Regular.woff") format("woff"), 
+         url("https://cdn.jsdelivr.net/gh/gleachkr/FiraLogic/dist/FiraLogic-Regular.tff") format("tff")
+}
+
+input {
+    font-family: "Fira Logic", monospace;
+    border-style:none;
+    margin:0px !important;
+    padding:0px;
+    font-size:12pt;
+}
+
+.label input {
+    text-align:center;
+}
+
+.label, .root {
+    display: flex;
+    flex-wrap: nowrap;
+    flex-direction: row;
+    justify-content: center;
+    line-height:1;
+}
+
+.root> *, .label > * {
+    display: inline-block;
+    padding:2px 5px 2px 5px;
+    box-sizing: content-box;
+}
+
+.forest {
+    display: flex;
+    flex-wrap: nowrap;
+    flex-direction: row;
+    justify-content: center;
+    align-items: flex-end;
+}
+
+.node {
+    display: inline-block;
+}
+
+.label > * {
+    border-bottom: 1px solid black;
+}
+
+.label > *:nth-child(1) {
+    flex-grow:1;
+}
+
+.label > *:nth-last-child(1) {
+    flex-grow:1;
+}
+
+.node:nth-child(1) > .label > *:nth-child(1) {
+    border-bottom: none; 
+}
+
+.node:last-child > .label > *:nth-child(3) {
+    border-bottom: none;
+    position:relative;
+    top:.8em;
+}
+
+.node > .label > *:nth-child(1) {
+    min-width:1em;
+}
+
+.node > .label > *:nth-child(3) {
+    min-width:1em;
+}
+
+.waiting input { color: gray }
+
+.parse-error input, .feedback input { color: red }
+
+.rule input {
+    font-size:8pt;
+    position:absolute;
+    max-width:5em;
+    text-overflow:ellipsis;
+}
+
+.rule input:focus {
+    max-width:none;
+}
+
+.rule > .rulePopper {
+    position:absolute;
+    bottom:25px;
+    visibility:hidden;
+    width: 400px;
+}
+
+.rule > .rulePopper > div {
+    background: white;
+    display:inline-block;
+    border:1px solid black;
+    padding:10px;
+    z-index:1;
+}
+
+.rule:hover > .rulePopper {
+    visibility:visible;
+}

--- a/Carnap-Server/static/js/proof.js
+++ b/Carnap-Server/static/js/proof.js
@@ -21,7 +21,7 @@ class ProofNode {
         if (obj) {
             this.label = obj.label;
             this.rule = obj.rule;
-            obj.forest.map(o => {this.addChild(o)})
+            if (obj.forest) obj.forest.map(o => {this.addChild(o)})
         };
     }
 

--- a/Carnap-Server/static/js/proof.js
+++ b/Carnap-Server/static/js/proof.js
@@ -1,0 +1,252 @@
+class ProofNode {
+    static input (init,calcwidth) {
+            var theInput = document.createElement("input")
+            if (init) theInput.value = init;
+            else theInput.setAttribute("style","width:1ch");
+            theInput.setAttribute("style","width:" + calcwidth(theInput) + "ch");
+            theInput.addEventListener('input', function () {
+                theInput.setAttribute("style","width:" + calcwidth(theInput) + "ch");
+            });
+            return theInput
+        };
+
+    constructor(obj) { 
+        this.forest = [];
+        this.labelContent = "";
+        this.ruleContent = "";
+        this.infoContent = "";
+        this.class = "";
+        this.parentNode = null
+
+        if (obj) {
+            this.label = obj.label;
+            this.rule = obj.rule;
+            obj.forest.map(o => {this.addChild(o)})
+        };
+    }
+
+    renderOn(target) {
+        var elt = document.createElement("div");
+
+        var forestElt = document.createElement("div");
+        elt.forestElt = forestElt
+        forestElt.setAttribute("class","forest");
+
+        elt.addRule = () => {
+            var childElt = forestElt.lastChild
+                if (childElt) {
+                var childLabel = childElt.lastChild
+                var ruleContainer = document.createElement("div");
+                var ruleInput = ProofNode.input(this.ruleContent, i => {return i.value.length});
+                elt.ruleElt = ruleInput;
+                ruleContainer.setAttribute("class","rule");
+                ruleContainer.appendChild(ruleInput);
+                childLabel.removeChild(childLabel.lastChild);
+                childLabel.appendChild(ruleContainer);
+                ruleInput.value = this.ruleContent;
+                ruleInput.addEventListener('input', () => {
+                    this.ruleContent = ruleInput.value
+                    this.trigger("changed", true, this);
+                });
+                this.on("infoChanged", (i,c) => {
+                    try {
+                        try {ruleContainer.popper.destroy()} catch (e) {}
+                        var msg = document.createElement("div");
+                        var wrapper = document.createElement("div");
+                        msg.innerHTML = i;
+                        wrapper.setAttribute("class","rulePopper")
+                        wrapper.appendChild(msg);
+                        ruleContainer.appendChild(wrapper);
+                        ruleContainer.setAttribute("class","rule " + c)
+                        ruleContainer.popper = new Popper(ruleInput,msg,{
+                            placement: "right",
+                            removeOnDestroy: true,
+                        });
+                    } catch(e) {
+                        console.log(e)
+                        ruleInput.setAttribute("title", i);
+                    }
+                });
+            }
+        }
+
+        var theChildElt = this.forest.map(n => {return n.renderOn(forestElt)})[0]
+
+        if (this.forest.length > 0) { elt.addRule() }
+
+        var labelElt = document.createElement("div");
+        if (!this.parentNode)  labelElt.setAttribute("class","root") 
+        else labelElt.setAttribute("class","label");
+        
+        var inputElt = ProofNode.input(this.label,i =>{
+            if (!this.parentNode) return i.value.length
+            else {
+                var myShare = this.parentNode.label.length / this.parentNode.forest.length
+                return Math.max(i.value.length,myShare)
+            }
+        })
+        this.on("labelChanged", l => {
+            if (l != inputElt.value) {
+                inputElt.value = l;
+                inputElt.dispatchEvent(new Event('input'))
+            }
+        });
+        this.on("siblingsChanged", () => {inputElt.dispatchEvent(new Event('input'))});
+        this.on("parentChanged", () => {inputElt.dispatchEvent(new Event('input'))});
+
+        inputElt.addEventListener('keyup', e => {
+            if (e.code == "Enter" && e.ctrlKey) {
+                e.preventDefault()
+                var newNode = this.addChild()
+                if (this.forest.length == 1) elt.ruleElt.focus();
+                else forestElt.firstChild.inputElt.focus();
+            } else if (e.code == "Enter") {
+                e.preventDefault();
+                var newNode = this.parentNode.addChild();
+                elt.parentElement.firstChild.inputElt.focus()
+            } else if (e.code == "Backspace" && e.ctrlKey) {
+                var parentElt = elt.parentElement.parentElement;
+                this.remove()
+                parentElt.inputElt.focus()
+                this.parentNode.trigger("changed", true, this)
+            };
+            this.label = inputElt.value
+            this.trigger("changed", true, this)
+            this.forest.map(n =>{n.trigger("parentChanged")})
+        });
+
+        elt.setAttribute("class","node");
+        elt.appendChild(forestElt);
+        elt.appendChild(labelElt);
+        labelElt.appendChild(document.createElement("div"));
+        labelElt.appendChild(inputElt);
+        labelElt.appendChild(document.createElement("div"));
+        elt.inputElt = inputElt;
+
+        this.on("removed", () => { 
+            var nodeAbove = elt.parentElement.parentElement
+            elt.parentElement.removeChild(elt);
+            if (this.parentNode.forest.length > 0) nodeAbove.addRule()
+        });
+
+        this.on("newChild", child => { 
+            child.renderOn(forestElt)
+            if (this.forest.length == 1) elt.addRule() 
+        });
+
+        target.prepend(elt);
+
+        return elt
+    }
+
+    get info() { return this.infoContent };
+
+    set info(i) { 
+        this.infoContent = i;
+        this.trigger("infoChanged", false, i, this.class)
+    }
+
+    get label() { return this.labelContent };
+
+    set label(l) { 
+        this.labelContent = l;
+        this.trigger("labelChanged", false, l) 
+        this.trigger("changed", true, this);
+    };
+
+    get rule() { return this.ruleContent };
+
+    set rule(r) { 
+        this.ruleContent = r;
+        this.trigger("ruleChanged", false, r)
+        this.trigger("changed", true, this);
+    };
+
+    addChild(obj) {
+        var child = new ProofNode(obj);
+        child.parentNode = this;
+        this.forest.push(child);
+        this.forest.map(n => {n.trigger("siblingsChanged")})
+        this.trigger("newChild", false, child);
+        this.trigger("changed", true, this);
+        return child;
+    };
+
+    remove() {
+        if (this.parentNode) {
+            this.trigger("removed",false);
+            this.parentNode.forest.splice(this.parentNode.forest.indexOf(this),1);
+            this.parentNode.forest.map(n => {n.trigger("siblingsChanged")})
+        }
+    };
+
+    toJSON() {
+        return {
+            label: this.label,
+            rule: this.rule,
+            forest: this.forest,
+        };
+    };
+
+    toInfo() {
+        return {
+            info: this.info,
+            class: this.class,
+            forest: this.forest.map(t => t.toInfo()),
+        };
+    };
+
+    decorate(obj) {
+        if (typeof(obj.class) != 'undefined') this.class = obj.class;
+        if (typeof(obj.info) != 'undefined') this.info = obj.info;
+        var i = 0;
+        if (typeof(obj.forest) != 'undefined') for (const o of this.forest) {
+            if (typeof(obj.forest[i]) != 'undefined') {
+                o.decorate(obj.forest[i]);
+            }
+            i++;
+        };
+    };
+
+    replace(obj) {
+        this.label = obj.label
+        this.rule = obj.rule
+        this.forest.map(n => {n.remove()});
+        obj.forest.map(o => {this.addChild(o)});
+    };
+
+    on(eventName, handler) {
+      if (!this._eventHandlers) this._eventHandlers = {};
+      if (!this._eventHandlers[eventName]) this._eventHandlers[eventName] = [];
+      this._eventHandlers[eventName].push(handler);
+    };
+
+    off(eventName, handler) {
+      let handlers = this._eventHandlers && this._eventHandlers[eventName];
+      if (!handlers) return;
+      for (let i = 0; i < handlers.length; i++) {
+        if (handlers[i] === handler) {
+          handlers.splice(i--, 1);
+        }
+      };
+    };
+
+    trigger(eventName, bubble, ...args) {
+      if (bubble && this.parentNode) {
+          this.parentNode.trigger(eventName, bubble, ...args)
+      }
+      if (!this._eventHandlers || !this._eventHandlers[eventName]) return;
+      this._eventHandlers[eventName].forEach(handler => handler.apply(this, args));
+    };
+};
+
+class ProofRoot extends ProofNode {
+    constructor(obj) {
+        super(obj)
+    };
+
+    renderOn(target) {
+        var elt = super.renderOn(target)
+        elt.inputElt.setAttribute("readonly","readonly")
+    }
+};

--- a/Carnap-Server/templates/infopage.hamlet
+++ b/Carnap-Server/templates/infopage.hamlet
@@ -187,6 +187,15 @@
 
                 <div.demo>
 
+                    <p> Carnap supports proofs written in the sequent calculus, via #
+                        <a href="">ProofJS
+                        \ Among the systems supported are propositional and first
+                        \ order variants of Gentzen's original LK and LJ.
+
+                    ^{sequentcheck 16 "foLK" "" "AxEy(F(x)/\\G(y)):|-:EyAx(F(x)/\\G(y))" sequentDemo}
+
+                <div.demo>
+
                     <p> Carnap also includes a JSON API, making it possible to
                         \ create pure JavaScript GUIs that use Carnap under
                         \ the hood for in-browser proof checking. Here's an example
@@ -198,7 +207,7 @@
                         \ system SL.
 
                     <div.exercise>
-                        <span> example 16
+                        <span> example 17
                         <div#klementProof>
                             (W ∨ X), (Y ∨ Z), X → Y, ¬Z ∴ W ∨ Y
 

--- a/Carnap-Server/templates/infopage.hamlet
+++ b/Carnap-Server/templates/infopage.hamlet
@@ -121,8 +121,8 @@
                     <p> Here are two more proofs of Russell's theorem, this
                         \ time using a version of system QL,
                         \ from P.D. Magnus' free and open textbook #
-                        <a href="https://www.fecundity.com/logic/">Forall x,
-                        \ and the system FOL from the #
+                        <a href="https://www.fecundity.com/logic/">Forall x#
+                        , and the system FOL from the #
                         <a href="https://github.com/rzach/forallx-yyc">Calgary remix
                         \ of #
                         <i>Forall x.
@@ -156,8 +156,9 @@
                 <div.demo>
 
                     <p> This is a proof that the powerset of a transitive set
-                        \ is transitive (exercise 3, chapter 3.3 from Velleman's
-                        \ <em>How to Prove It</em>), in a system of elementary set theory.
+                        \ is transitive (exercise 3, chapter 3.3 from Velleman's #
+                        <em>How to Prove It#
+                        ), in a system of elementary set theory.
 
                     ^{proofcheck 12 "elementarySetTheory" "render resize" "a within P(a) :|-: P(a) within P(P(a)) " transitiveTheorem}
 
@@ -166,7 +167,8 @@
                     <p> Here are proofs of axioms 5 and B within natural
                         \ deduction systems for propositional modal logics K5
                         \ and KTB, in the style of Hardegree's #
-                        <a href="http://courses.umass.edu/phil511-gmh/MAIN/IHome-1.htm">Modal Logic.
+                        <a href="http://courses.umass.edu/phil511-gmh/MAIN/IHome-1.htm">Modal Logic#
+                        .
                     <p> These use #
                         <a href="https://github.com/gleachkr/FiraLogic">Fira Logic
                         \ for nicer-looking logical symbols and use guards to
@@ -181,15 +183,16 @@
                     <p> Here's a proof of the Barcan Formula within a naïvely
                         \ quantified system of modal logic, based on the system
                         \ MPL of Hardegree's #
-                        <a href="http://courses.umass.edu/phil511-gmh/MAIN/IHome-1.htm">Modal Logic.
+                        <a href="http://courses.umass.edu/phil511-gmh/MAIN/IHome-1.htm">Modal Logic#
+                        .
 
                     ^{proofcheck 15 "hardegreeMPL" "fonts guides resize" ":|-: Ax[]Fx->[]AxFx" barcanTheorem}
 
                 <div.demo>
 
                     <p> Carnap supports proofs written in the sequent calculus, via #
-                        <a href="">ProofJS
-                        \ Among the systems supported are propositional and first
+                        <a href="https://github.com/gleachkr/ProofJS">ProofJS#
+                        . Among the systems supported are propositional and first
                         \ order variants of Gentzen's original LK and LJ.
 
                     ^{sequentcheck 16 "foLK" "" "AxEy(F(x)/\\G(y)):|-:EyAx(F(x)/\\G(y))" sequentDemo}

--- a/Carnap-Server/templates/infopage.julius
+++ b/Carnap-Server/templates/infopage.julius
@@ -23,7 +23,7 @@ function updateSlider(newelt){
 };
 
 function initializeVisible () {
-    document.querySelectorAll(".visible textarea").forEach(
+    document.querySelectorAll(".visible .input").forEach(
     function (el) {
         el.dispatchEvent(initialize);
     });

--- a/Carnap-Server/templates/user.hamlet
+++ b/Carnap-Server/templates/user.hamlet
@@ -43,6 +43,10 @@
         <div.card>
             <div.card-header> Qualitative Problems
             #{qtable}
+    $if (not $ null seqsubs)
+        <div.card>
+            <div.card-header> Sequent Calculus Problems
+            #{seqtable}
     <h3> Your Profile
     ^{personalInfo ud (Just course)}
     $if (not (null derivedRulesOld) || not (null derivedRulesNew))

--- a/Carnap/Carnap.cabal
+++ b/Carnap/Carnap.cabal
@@ -72,6 +72,7 @@ library
                      , Carnap.Languages.PureFirstOrder.Logic.HowardSnyder
                      , Carnap.Languages.PureFirstOrder.Logic.Hardegree
                      , Carnap.Languages.PureFirstOrder.Logic.Goldfarb
+                     , Carnap.Languages.PureFirstOrder.Logic.Gentzen
                      , Carnap.Languages.PureSecondOrder.Syntax
                      , Carnap.Languages.PureSecondOrder.Parser
                      , Carnap.Languages.PureSecondOrder.Logic

--- a/Carnap/Carnap.cabal
+++ b/Carnap/Carnap.cabal
@@ -92,6 +92,7 @@ library
                      , Carnap.Calculi.NaturalDeduction.Parser.StructuredFitch
                      , Carnap.Calculi.NaturalDeduction.Syntax
                      , Carnap.Calculi.NaturalDeduction.Util
+                     , Carnap.Calculi.Tableau.Data
 
   build-depends:       base >= 4.7
                      , lens >= 4.12

--- a/Carnap/Carnap.cabal
+++ b/Carnap/Carnap.cabal
@@ -6,7 +6,7 @@ license:             GPL-3
 license-file:        LICENSE
 author:              Jake Ehrlich, Graham Leach-Krouse
 maintainer:          gleachkr@gmail.com
-copyright:           2016 Jake Ehrlich, Graham Leach-Krouse
+copyright:           2019 Jake Ehrlich, Graham Leach-Krouse
 category:            Web
 build-type:          Simple
 -- extra-source-files:

--- a/Carnap/Carnap.cabal
+++ b/Carnap/Carnap.cabal
@@ -82,6 +82,7 @@ library
                      , Carnap.Languages.SetTheory.Logic.Carnap
                      , Carnap.Languages.ClassicalSequent.Syntax
                      , Carnap.Languages.ClassicalSequent.Parser
+                     , Carnap.Calculi.Util
                      , Carnap.Calculi.NaturalDeduction.Checker
                      , Carnap.Calculi.NaturalDeduction.Parser
                      , Carnap.Calculi.NaturalDeduction.Parser.Util

--- a/Carnap/Carnap.cabal
+++ b/Carnap/Carnap.cabal
@@ -45,6 +45,7 @@ library
                      , Carnap.Languages.PurePropositional.Logic.Hardegree
                      , Carnap.Languages.PurePropositional.Logic.ThomasBolducAndZach
                      , Carnap.Languages.PurePropositional.Logic.Tomassi
+                     , Carnap.Languages.PurePropositional.Logic.Gentzen
                      , Carnap.Languages.ModalPropositional.Syntax
                      , Carnap.Languages.ModalPropositional.Parser
                      , Carnap.Languages.ModalPropositional.Logic

--- a/Carnap/Carnap.cabal
+++ b/Carnap/Carnap.cabal
@@ -94,6 +94,7 @@ library
                      , Carnap.Calculi.NaturalDeduction.Syntax
                      , Carnap.Calculi.NaturalDeduction.Util
                      , Carnap.Calculi.Tableau.Data
+                     , Carnap.Calculi.Tableau.Checker
 
   build-depends:       base >= 4.7
                      , lens >= 4.12

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Checker.hs
@@ -84,10 +84,10 @@ toDisplaySequenceStructured pl ded@(SubProof (1,m) ls) = let feedback = map (pl 
 
 
 processLineHardegree :: 
-  ( Sequentable lex
-  , Inference r lex sem
+  ( Inference r lex sem
+  , ACUI (ClassicalSequentOver lex)
+  , Sequentable lex
   , Typeable sem
-  , FirstOrderLex (lex (ClassicalSequentOver lex))
   , StaticVar (ClassicalSequentOver lex)
   , MonadVar (ClassicalSequentOver lex) (State Int)
   ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
@@ -131,7 +131,7 @@ processLineMontague ::
   , Typeable sem
   , MonadVar (ClassicalSequentOver lex) (State Int)
   , StaticVar (ClassicalSequentOver lex)
-  , FirstOrderLex (lex (ClassicalSequentOver lex))
+  , ACUI (ClassicalSequentOver lex)
   ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
 processLineMontague ded res n = case ded !! (n - 1) of
   --special case to catch QedLines not being cited in justifications
@@ -143,7 +143,7 @@ hoProcessLineMontague ::
   , Sequentable lex
   , Inference r lex sem
   , Typeable sem
-  , FirstOrderLex (lex (ClassicalSequentOver lex))
+  , ACUI (ClassicalSequentOver lex)
   , MonadVar (ClassicalSequentOver lex) (State Int)
   ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
 hoProcessLineMontague ded res n = case ded !! (n - 1) of
@@ -174,7 +174,6 @@ processLineFitch ::
   , MonadVar (ClassicalSequentOver lex) (State Int)
   , Typeable sem
   , ACUI (ClassicalSequentOver lex)
-  , FirstOrderLex (lex (ClassicalSequentOver lex))
   ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
 processLineFitch ded res n = case ded !! (n - 1) of
   --special case to catch QedLines not being cited in justifications
@@ -198,7 +197,7 @@ hoProcessLineFitchMemo ::
   ( StaticVar (ClassicalSequentOver lex)
   , Sequentable lex
   , Inference r lex sem
-  , FirstOrderLex (lex (ClassicalSequentOver lex))
+  , ACUI (ClassicalSequentOver lex)
   , Typeable sem
   , MonadVar (ClassicalSequentOver lex) (State Int)
   , Show (ClassicalSequentOver lex (Succedent sem)), Show r
@@ -212,7 +211,7 @@ hoProcessLineFitchMemo ref ded res n = case ded !! (n - 1) of
 processLineLemmon :: 
   ( Sequentable lex
   , Inference r lex sem
-  , FirstOrderLex (lex (ClassicalSequentOver lex))
+  , ACUI (ClassicalSequentOver lex)
   , StaticVar (ClassicalSequentOver lex)
   , MonadVar (ClassicalSequentOver lex) (State Int)
   , Typeable sem
@@ -226,7 +225,7 @@ hoProcessLineLemmon ::
   ( StaticVar (ClassicalSequentOver lex)
   , Sequentable lex
   , Typeable sem
-  , FirstOrderLex (lex (ClassicalSequentOver lex))
+  , ACUI (ClassicalSequentOver lex)
   , Inference r lex sem
   , MonadVar (ClassicalSequentOver lex) (State Int)
   ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
@@ -240,7 +239,7 @@ hoProcessLineLemmonMemo ::
   , Sequentable lex
   , Inference r lex sem
   , Typeable sem
-  , FirstOrderLex (lex (ClassicalSequentOver lex))
+  , ACUI (ClassicalSequentOver lex)
   , MonadVar (ClassicalSequentOver lex) (State Int)
   , Show (ClassicalSequentOver lex (Succedent sem)), Show r
   ) => ProofMemoRef lex sem r -> Deduction r lex sem -> Restrictor r lex -> Int -> IO (FeedbackLine lex sem)
@@ -254,7 +253,7 @@ processLineStructuredFitch ::
   ( Sequentable lex
   , Inference r lex sem
   , Typeable sem
-  , FirstOrderLex (lex (ClassicalSequentOver lex))
+  , ACUI (ClassicalSequentOver lex)
   , MonadVar (ClassicalSequentOver lex) (State Int)
   , StaticVar (ClassicalSequentOver lex)
   ) => DeductionTree r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
@@ -268,7 +267,7 @@ processLineStructuredFitchHO ::
   , Sequentable lex
   , Inference r lex sem
   , Typeable sem
-  , FirstOrderLex (lex (ClassicalSequentOver lex))
+  , ACUI (ClassicalSequentOver lex)
   , MonadVar (ClassicalSequentOver lex) (State Int)
   ) => DeductionTree r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
 processLineStructuredFitchHO ded res n = case ded .! n of

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Checker.hs
@@ -15,9 +15,8 @@ import Carnap.Core.Data.Types
 import Carnap.Core.Data.Classes
 import Carnap.Core.Data.Util (rebuild)
 import Carnap.Core.Unification.Unification
-import Carnap.Core.Unification.FirstOrder
-import Carnap.Core.Unification.Huet
 import Carnap.Core.Unification.ACUI
+import Carnap.Calculi.Util
 import Carnap.Languages.ClassicalSequent.Syntax
 import Control.Lens
 import Control.Monad.State
@@ -454,30 +453,6 @@ hoReduceProofTreeMemo ref res pt@(Node (ProofLine no cont rules) ts) =
                                    checkAgainst (restriction rule) no sub
                                    return rslt
 
-fosolve :: 
-    ( FirstOrder (ClassicalSequentOver lex)
-    , MonadVar (ClassicalSequentOver lex) (State Int)
-    ) =>  [Equation (ClassicalSequentOver lex)] -> Either (ProofErrorMessage lex) [Equation (ClassicalSequentOver lex)]
-fosolve eqs = case evalState (foUnifySys (const False) eqs) (0 :: Int) of 
-                [] -> Left $ NoUnify [eqs] 0
-                [s] -> Right s
-
-hosolve :: 
-    ( HigherOrder (ClassicalSequentOver lex)
-    , MonadVar (ClassicalSequentOver lex) (State Int)
-    ) => [Equation (ClassicalSequentOver lex)] -> Either (ProofErrorMessage lex) [[Equation (ClassicalSequentOver lex)]]
-hosolve eqs = case evalState (huetUnifySys (const False) eqs) (0 :: Int) of
-                    [] -> Left $ NoUnify [eqs] 0
-                    subs -> Right subs
-
-acuisolve :: 
-    ( ACUI (ClassicalSequentOver lex)
-    , MonadVar (ClassicalSequentOver lex) (State Int)
-    ) => [Equation (ClassicalSequentOver lex)] -> Either (ProofErrorMessage lex) [[Equation (ClassicalSequentOver lex)]]
-acuisolve eqs = 
-        case evalState (acuiUnifySys (const False) eqs) (0 :: Int) of
-          [] -> Left $ NoUnify [eqs] 0
-          subs -> Right subs
 
 checkAgainst (Just f) n sub = case f sub of
                                   Nothing -> Right sub

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Checker.hs
@@ -33,13 +33,11 @@ import Data.Maybe (isNothing)
 --Main Functions
 --------------------------------------------------------
 
--- XXX Clean this up and reduce duplication
-
 toDisplaySequence:: 
     ( MonadVar (ClassicalSequentOver lex) (State Int)
     , Inference r lex sem, Sequentable lex
-    ) =>  (Deduction r lex sem -> Restrictor r lex -> Int ->   FeedbackLine lex sem) 
-            -> Deduction r lex sem -> Feedback lex sem
+    ) => (Deduction r lex sem -> Restrictor r lex -> Int ->   FeedbackLine lex sem) 
+           -> Deduction r lex sem -> Feedback lex sem
 toDisplaySequence pl ded = let feedback = map (pl ded res) [1 .. length ded] in
                                   Feedback (lastTopInd >>= fromFeedback feedback) feedback
                           
@@ -53,8 +51,8 @@ toDisplaySequence pl ded = let feedback = map (pl ded res) [1 .. length ded] in
 toDisplaySequenceMemo :: 
     ( MonadVar (ClassicalSequentOver lex) (State Int)
     , Inference r lex sem, Sequentable lex
-    ) =>  (Deduction r lex sem -> Restrictor r lex -> Int ->  IO (FeedbackLine lex sem)) 
-            -> Deduction r lex sem -> IO (Feedback lex sem)
+    ) => (Deduction r lex sem -> Restrictor r lex -> Int ->  IO (FeedbackLine lex sem)) 
+           -> Deduction r lex sem -> IO (Feedback lex sem)
 toDisplaySequenceMemo pl ded = 
         do feedback <- mapM (pl ded res) [1 .. length ded]
            return $ Feedback (lastTopInd >>= fromFeedback feedback) feedback
@@ -69,7 +67,8 @@ toDisplaySequenceMemo pl ded =
 toDisplaySequenceStructured:: 
     ( MonadVar (ClassicalSequentOver lex) (State Int)
     , Inference r lex sem, Sequentable lex
-    ) =>  (DeductionTree r lex sem -> Restrictor r lex -> Int  -> FeedbackLine lex sem) -> DeductionTree r lex sem -> Feedback lex sem
+    ) => (DeductionTree r lex sem -> Restrictor r lex -> Int  -> FeedbackLine lex sem) 
+           -> DeductionTree r lex sem -> Feedback lex sem
 toDisplaySequenceStructured pl ded@(SubProof (1,m) ls) = let feedback = map (pl ded res) [1 .. m] in
                                   Feedback (lastTopInd >>= fromFeedback feedback) feedback
                           
@@ -81,41 +80,66 @@ toDisplaySequenceStructured pl ded@(SubProof (1,m) ls) = let feedback = map (pl 
             Right s -> if alright fb then Just s else Nothing
           res = globalRestriction (Right ded)
 
-processLineHardegree :: 
-  ( Inference r lex sem
-  , ACUI (ClassicalSequentOver lex)
-  , Sequentable lex
-  , Typeable sem
-  , StaticVar (ClassicalSequentOver lex)
-  , MonadVar (ClassicalSequentOver lex) (State Int)
-  ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
+processLineHardegree, hoProcessLineHardegree, processLineMontague,
+    hoProcessLineMontague, processLineFitch, hoProcessLineFitch,
+    processLineLemmon, hoProcessLineLemmon :: 
+    ( Inference r lex sem
+    , ACUI (ClassicalSequentOver lex)
+    , Sequentable lex
+    , Typeable sem
+    , StaticVar (ClassicalSequentOver lex)
+    , MonadVar (ClassicalSequentOver lex) (State Int)
+    ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
 processLineHardegree ded res n = case ded !! (n - 1) of
   --special case to catch QedLines not being cited in justifications
   (QedLine _ _ _) -> Left $ NoResult n
   _ -> toProofTreeHardegree ded n >>= reduceProofTree res
 
-hoProcessLineHardegree :: 
-  ( StaticVar (ClassicalSequentOver lex)
-  , Sequentable lex
-  , Inference r lex sem
-  , Typeable sem
-  , ACUI (ClassicalSequentOver lex)
-  , MonadVar (ClassicalSequentOver lex) (State Int)
-  ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
 hoProcessLineHardegree ded res n = case ded !! (n - 1) of
   --special case to catch QedLines not being cited in justifications
   (QedLine _ _ _) -> Left $ NoResult n
   _ -> toProofTreeHardegree ded n >>= hoReduceProofTree res
 
-hoProcessLineHardegreeMemo :: 
-  ( StaticVar (ClassicalSequentOver lex)
-  , ACUI (ClassicalSequentOver lex)
-  , Sequentable lex
-  , Inference r lex sem
-  , Typeable sem
-  , MonadVar (ClassicalSequentOver lex) (State Int)
-  , Show (ClassicalSequentOver lex (Succedent sem)), Show r
-  ) => ProofMemoRef lex sem r -> Deduction r lex sem -> Restrictor r lex -> Int -> IO (FeedbackLine lex sem)
+processLineMontague ded res n = case ded !! (n - 1) of
+  --special case to catch QedLines not being cited in justifications
+  (QedLine _ _ _) -> Left $ NoResult n
+  _ -> toProofTreeMontague ded n >>= reduceProofTree res
+  
+hoProcessLineMontague ded res n = case ded !! (n - 1) of
+  --special case to catch QedLines not being cited in justifications
+  (QedLine _ _ _) -> Left $ NoResult n
+  _ -> toProofTreeMontague ded n >>= hoReduceProofTree res
+
+processLineFitch ded res n = case ded !! (n - 1) of
+  --special case to catch QedLines not being cited in justifications
+  (QedLine _ _ _) -> Left $ NoResult n
+  _ -> toProofTreeFitch ded n >>= reduceProofTree res
+
+hoProcessLineFitch ded res n = case ded !! (n - 1) of
+  --special case to catch QedLines not being cited in justifications
+  (QedLine _ _ _) -> Left $ NoResult n
+  _ -> toProofTreeFitch ded n >>= hoReduceProofTree res
+
+processLineLemmon ded res n = case ded !! (n - 1) of
+  --special case to catch QedLines not being cited in justifications
+  (QedLine _ _ _) -> Left $ NoResult n
+  _ -> toProofTreeLemmon ded n >>= reduceProofTree res
+
+hoProcessLineLemmon ded res n = case ded !! (n - 1) of
+  --special case to catch QedLines not being cited in justifications
+  (QedLine _ _ _) -> Left $ NoResult n
+  _ -> toProofTreeLemmon ded n >>= hoReduceProofTree res
+
+hoProcessLineHardegreeMemo, hoProcessLineMontagueMemo,
+    hoProcessLineFitchMemo, hoProcessLineLemmonMemo  :: 
+    ( StaticVar (ClassicalSequentOver lex)
+    , ACUI (ClassicalSequentOver lex)
+    , Sequentable lex
+    , Inference r lex sem
+    , Typeable sem
+    , MonadVar (ClassicalSequentOver lex) (State Int)
+    , Show (ClassicalSequentOver lex (Succedent sem)), Show r
+    ) => ProofMemoRef lex sem r -> Deduction r lex sem -> Restrictor r lex -> Int -> IO (FeedbackLine lex sem)
 hoProcessLineHardegreeMemo ref ded res n = case ded !! (n - 1) of
   --special case to catch QedLines not being cited in justifications
   (QedLine _ _ _) -> return $ Left $ NoResult n
@@ -123,41 +147,6 @@ hoProcessLineHardegreeMemo ref ded res n = case ded !! (n - 1) of
         Right t -> hoReduceProofTreeMemo ref res t 
         Left e -> return $ Left e
 
-processLineMontague :: 
-  ( Sequentable lex
-  , Inference r lex sem
-  , Typeable sem
-  , MonadVar (ClassicalSequentOver lex) (State Int)
-  , StaticVar (ClassicalSequentOver lex)
-  , ACUI (ClassicalSequentOver lex)
-  ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
-processLineMontague ded res n = case ded !! (n - 1) of
-  --special case to catch QedLines not being cited in justifications
-  (QedLine _ _ _) -> Left $ NoResult n
-  _ -> toProofTreeMontague ded n >>= reduceProofTree res
-  
-hoProcessLineMontague :: 
-  ( StaticVar (ClassicalSequentOver lex)
-  , Sequentable lex
-  , Inference r lex sem
-  , Typeable sem
-  , ACUI (ClassicalSequentOver lex)
-  , MonadVar (ClassicalSequentOver lex) (State Int)
-  ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
-hoProcessLineMontague ded res n = case ded !! (n - 1) of
-  --special case to catch QedLines not being cited in justifications
-  (QedLine _ _ _) -> Left $ NoResult n
-  _ -> toProofTreeMontague ded n >>= hoReduceProofTree res
-
-hoProcessLineMontagueMemo :: 
-  ( StaticVar (ClassicalSequentOver lex)
-  , Sequentable lex
-  , Inference r lex sem
-  , Typeable sem
-  , ACUI (ClassicalSequentOver lex)
-  , MonadVar (ClassicalSequentOver lex) (State Int)
-  , Show (ClassicalSequentOver lex (Succedent sem)), Show r
-  ) => ProofMemoRef lex sem r -> Deduction r lex sem -> Restrictor r lex -> Int -> IO (FeedbackLine lex sem)
 hoProcessLineMontagueMemo ref ded res n = case ded !! (n - 1) of
   --special case to catch QedLines not being cited in justifications
   (QedLine _ _ _) -> return $ Left $ NoResult n
@@ -165,89 +154,19 @@ hoProcessLineMontagueMemo ref ded res n = case ded !! (n - 1) of
         Right t -> hoReduceProofTreeMemo ref res t
         Left e -> return $ Left e
 
-processLineFitch :: 
-  ( Sequentable lex
-  , Inference r lex sem
-  , StaticVar (ClassicalSequentOver lex)
-  , MonadVar (ClassicalSequentOver lex) (State Int)
-  , Typeable sem
-  , ACUI (ClassicalSequentOver lex)
-  ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
-processLineFitch ded res n = case ded !! (n - 1) of
-  --special case to catch QedLines not being cited in justifications
-  (QedLine _ _ _) -> Left $ NoResult n
-  _ -> toProofTreeFitch ded n >>= reduceProofTree res
-
-hoProcessLineFitch :: 
-  ( StaticVar (ClassicalSequentOver lex)
-  , Sequentable lex
-  , Typeable sem
-  , Inference r lex sem
-  , ACUI (ClassicalSequentOver lex)
-  , MonadVar (ClassicalSequentOver lex) (State Int)
-  ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
-hoProcessLineFitch ded res n = case ded !! (n - 1) of
-  --special case to catch QedLines not being cited in justifications
-  (QedLine _ _ _) -> Left $ NoResult n
-  _ -> toProofTreeFitch ded n >>= hoReduceProofTree res
-
-hoProcessLineFitchMemo :: 
-  ( StaticVar (ClassicalSequentOver lex)
-  , Sequentable lex
-  , Inference r lex sem
-  , ACUI (ClassicalSequentOver lex)
-  , Typeable sem
-  , MonadVar (ClassicalSequentOver lex) (State Int)
-  , Show (ClassicalSequentOver lex (Succedent sem)), Show r
-  ) => ProofMemoRef lex sem r -> Deduction r lex sem -> Restrictor r lex -> Int -> IO (FeedbackLine lex sem)
 hoProcessLineFitchMemo ref ded res n = case ded !! (n - 1) of
   (QedLine _ _ _) -> return $ Left $ NoResult n
   _ -> case toProofTreeFitch ded n of
         Right t -> hoReduceProofTreeMemo ref res t
         Left e -> return $ Left e
 
-processLineLemmon :: 
-  ( Sequentable lex
-  , Inference r lex sem
-  , ACUI (ClassicalSequentOver lex)
-  , StaticVar (ClassicalSequentOver lex)
-  , MonadVar (ClassicalSequentOver lex) (State Int)
-  , Typeable sem
-  ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
-processLineLemmon ded res n = case ded !! (n - 1) of
-  --special case to catch QedLines not being cited in justifications
-  (QedLine _ _ _) -> Left $ NoResult n
-  _ -> toProofTreeLemmon ded n >>= reduceProofTree res
-
-hoProcessLineLemmon :: 
-  ( StaticVar (ClassicalSequentOver lex)
-  , Sequentable lex
-  , Typeable sem
-  , ACUI (ClassicalSequentOver lex)
-  , Inference r lex sem
-  , MonadVar (ClassicalSequentOver lex) (State Int)
-  ) => Deduction r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
-hoProcessLineLemmon ded res n = case ded !! (n - 1) of
-  --special case to catch QedLines not being cited in justifications
-  (QedLine _ _ _) -> Left $ NoResult n
-  _ -> toProofTreeLemmon ded n >>= hoReduceProofTree res
-
-hoProcessLineLemmonMemo :: 
-  ( StaticVar (ClassicalSequentOver lex)
-  , Sequentable lex
-  , Inference r lex sem
-  , Typeable sem
-  , ACUI (ClassicalSequentOver lex)
-  , MonadVar (ClassicalSequentOver lex) (State Int)
-  , Show (ClassicalSequentOver lex (Succedent sem)), Show r
-  ) => ProofMemoRef lex sem r -> Deduction r lex sem -> Restrictor r lex -> Int -> IO (FeedbackLine lex sem)
 hoProcessLineLemmonMemo ref ded res n = case ded !! (n - 1) of
   (QedLine _ _ _) -> return $ Left $ NoResult n
   _ -> case toProofTreeLemmon ded n of
         Right t -> hoReduceProofTreeMemo ref res t
         Left e -> return $ Left e
 
-processLineStructuredFitch :: 
+processLineStructuredFitch, processLineStructuredFitchHO :: 
   ( Sequentable lex
   , Inference r lex sem
   , Typeable sem
@@ -260,14 +179,6 @@ processLineStructuredFitch ded res n = case ded .! n of
   Just (QedLine _ _ _) -> Left $ NoResult n
   _ -> toProofTreeStructuredFitch ded n >>= reduceProofTree res
 
-processLineStructuredFitchHO :: 
-  ( StaticVar (ClassicalSequentOver lex)
-  , Sequentable lex
-  , Inference r lex sem
-  , Typeable sem
-  , ACUI (ClassicalSequentOver lex)
-  , MonadVar (ClassicalSequentOver lex) (State Int)
-  ) => DeductionTree r lex sem -> Restrictor r lex -> Int -> FeedbackLine lex sem
 processLineStructuredFitchHO ded res n = case ded .! n of
   --special case to catch QedLines not being cited in justifications
   Just (QedLine _ _ _) -> Left $ NoResult n
@@ -313,7 +224,7 @@ reduceResult lineno xs = case rights xs of
 --return an error or a list of possible (schematic-variable-free) correct
 --conclusion sequents
 
-foseqFromNode :: 
+foseqFromNode, hoseqFromNode  :: 
     ( Inference r lex sem
     , MonadVar (ClassicalSequentOver lex) (State Int)
     , StaticVar (ClassicalSequentOver lex)
@@ -349,19 +260,6 @@ foseqFromNode lineno rules prems conc =
                                    (map (view lhs) prems))
                             return $ map (\x -> (antecedentNub $ applySub x subbedconc,x,r)) (map (++ fosub) acuisubs)
 
-hoseqFromNode :: 
-    ( Inference r lex sem
-    , MonadVar (ClassicalSequentOver lex) (State Int)
-    , FirstOrder (ClassicalSequentOver lex)
-    , ACUI (ClassicalSequentOver lex)
-    , StaticVar (ClassicalSequentOver lex)
-    , Typeable sem
-    ) =>  Int -> [r] -> [ClassicalSequentOver lex (Sequent sem)] -> ClassicalSequentOver lex (Succedent sem)
-              -> [Either (ProofErrorMessage lex) 
-                         [( ClassicalSequentOver lex (Sequent sem)
-                          , [Equation (ClassicalSequentOver lex)]
-                          , r
-                          )]]
 hoseqFromNode lineno rules prems conc = 
         do r <- rules
            --run a non-deterministic computation over all permutations of
@@ -391,7 +289,7 @@ hoseqFromNode lineno rules prems conc =
                                        [] -> return $ Left $ renumber lineno $ NoUnify [prob] 0
                                        subs -> return $ Right $ map (\x -> (antecedentNub $ applySub x subbedconc,x,r)) (map (++ hosub) subs)
 
-reduceProofTree :: 
+reduceProofTree, hoReduceProofTree :: 
     ( Inference r lex sem
     , FirstOrder (ClassicalSequentOver lex)
     , ACUI (ClassicalSequentOver lex)
@@ -406,14 +304,6 @@ reduceProofTree res (Node (ProofLine no cont rules) ts) =
            checkAgainst (restriction rule) no sub
            return rslt
 
-hoReduceProofTree :: 
-    ( Inference r lex sem
-    , MonadVar (ClassicalSequentOver lex) (State Int)
-    , ACUI (ClassicalSequentOver lex)
-    , FirstOrder (ClassicalSequentOver lex)
-    , StaticVar (ClassicalSequentOver lex)
-    , Typeable sem
-    ) =>  Restrictor r lex -> ProofTree r lex sem -> FeedbackLine lex sem
 hoReduceProofTree res (Node (ProofLine no cont rules) ts) =  
         do prems <- mapM (hoReduceProofTree res) ts
            (rslt, sub, rule) <- reduceResult no $ hoseqFromNode no rules prems cont 

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Checker.hs
@@ -50,7 +50,6 @@ toDisplaySequence pl ded = let feedback = map (pl ded res) [1 .. length ded] in
             Right s -> if alright fb then Just s else Nothing
           res = globalRestriction (Left ded)
 
-
 toDisplaySequenceMemo :: 
     ( MonadVar (ClassicalSequentOver lex) (State Int)
     , Inference r lex sem, Sequentable lex
@@ -81,7 +80,6 @@ toDisplaySequenceStructured pl ded@(SubProof (1,m) ls) = let feedback = map (pl 
             Left _ -> Nothing
             Right s -> if alright fb then Just s else Nothing
           res = globalRestriction (Right ded)
-
 
 processLineHardegree :: 
   ( Inference r lex sem

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Checker.hs
@@ -453,7 +453,6 @@ hoReduceProofTreeMemo ref res pt@(Node (ProofLine no cont rules) ts) =
                                    checkAgainst (restriction rule) no sub
                                    return rslt
 
-
 checkAgainst (Just f) n sub = case f sub of
                                   Nothing -> Right sub
                                   Just s -> Left $ GenericError s n

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/Fitch.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/Fitch.hs
@@ -7,6 +7,7 @@ import Data.Typeable
 import Data.List (delete, (\\))
 import Text.Parsec
 import Carnap.Core.Data.Types
+import Carnap.Calculi.Util
 import Carnap.Calculi.NaturalDeduction.Syntax
 import Carnap.Calculi.NaturalDeduction.Parser.Util
 import Carnap.Languages.ClassicalSequent.Syntax

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/Hardegree.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/Hardegree.hs
@@ -7,6 +7,7 @@ import Data.Typeable
 import Data.List (findIndex)
 import Text.Parsec
 import Carnap.Core.Data.Types
+import Carnap.Calculi.Util
 import Carnap.Calculi.NaturalDeduction.Syntax
 import Carnap.Calculi.NaturalDeduction.Parser.Util
 import Carnap.Languages.ClassicalSequent.Syntax

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/Lemmon.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/Lemmon.hs
@@ -7,6 +7,7 @@ import Data.Typeable
 import Data.List (sort,(\\),nub)
 import Text.Parsec
 import Carnap.Core.Data.Types
+import Carnap.Calculi.Util
 import Carnap.Calculi.NaturalDeduction.Syntax
 import Carnap.Calculi.NaturalDeduction.Parser.Util
 import Carnap.Languages.ClassicalSequent.Syntax

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/Lemmon.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/Lemmon.hs
@@ -32,7 +32,7 @@ parseDependentAssertLinePlain = parseDependentAssertLine False
 
 --lemmon justifications as given in Goldfarb
 lemline r = do mdis <- optionMaybe scope
-               let dis = case mdis of Nothing -> []; Just l -> l
+               let dis = case mdis of Nothing -> Just []; l -> l
                spaces
                deps <- citation `sepEndBy` spaces
                annote <- annotation
@@ -45,7 +45,7 @@ lemlineAlt r = do (dis,deps,annote) <- lookAhead $
                     do many (oneOf ['A' .. 'Z'])
                        (mdis,mdeps,annote) <- try cite1 <|> try cite2 <|> cite3
                        let deps = case mdeps of Nothing -> []; Just l -> l
-                       let dis = case mdis of Nothing -> []; Just l -> l
+                       let dis = case mdis of Nothing -> Just []; l -> l
                        return (dis,deps,annote)
                   rule <- r (length deps) annote
                   return (dis,deps,rule)
@@ -59,8 +59,9 @@ lemlineImplicit r = do indicated <- parseInts
                        spaces
                        rule <- r 0 ""
                        --XXX: discharge of assumptions is done implicitly,
-                       --rather than explicitly flagged in this system
-                       return ([],indicated,rule)
+                       --rather than explicitly flagged in this system.
+                       --Hence "Nothing" is discharged
+                       return (Nothing,indicated,rule)
 
 citation :: Parsec String u Int
 citation = char '(' *> (read <$> many1 digit) <* char ')'
@@ -95,13 +96,13 @@ toProofTreeLemmon ::
     , Typeable sem
     ) => Deduction r lex sem -> Int -> Either (ProofErrorMessage lex) (ProofTree r lex sem)
 toProofTreeLemmon ded n = case ded !! (n - 1) of
-    (DependentAssertLine f r depairs dis scope mnum) ->
+    l@(DependentAssertLine f r depairs mdis scope mnum) ->
         do let deps = map fst depairs
            mapM_ checkDep deps
            checkNum mnum
            let inherited = concat $ map (\m -> inScope (ded !! (m - 1))) deps
            checkScope inherited
-           deps' <- mapM (toProofTreeLemmon ded) (deps ++ dis)
+           deps' <- mapM (toProofTreeLemmon ded) (deps ++ discharged l)
            return $ Node (ProofLine n (SS $ liftToSequent f) r) deps'
 
         where err :: String -> Either (ProofErrorMessage lex) a
@@ -111,12 +112,13 @@ toProofTreeLemmon ded n = case ded !! (n - 1) of
                          | otherwise = Right True
 
               checkScope i | isAssumption (head r) && not (scope == i ++ [n]) = err "The dependencies here aren't right. Remember, this rule introduces its own line number as a dependency."
-                           | isAssumption (head r) = if dis /= [] then err "This rule does not allow the elimination of dependencies." else Right True
-                           | null (globalRestriction (Left []) 0 (head r)) && dis /= [] = err "This rule does not allow the elimination of dependencies."
-                           | null (indirectInference (head r)) = if sort scope /= sort (nub i \\ dis) then err "The dependencies here aren't right. Did you forget mark a dependency as eliminated?."
-                                                                                                      else Right True
+                           | isAssumption (head r) = if nodis then Right True else err "This rule does not allow the elimination of dependencies."
+                           | null (globalRestriction (Left []) 0 (head r)) && not nodis = err "This rule does not allow the elimination of dependencies."
                            | length (nub i) - numDischarged (indirectInference (head r)) /= length scope = err "This is the wrong number of dependencies. Did you forget to add or remove something?"
+                           | mdis /= Nothing && sort scope /= sort (nub i \\ discharged l) = err "The dependencies here aren't right. Did you forget mark a dependency as eliminated?."
                            | otherwise = Right True
+
+              nodis = discharged l == []
 
               numDischarged (Just (TypedProof (ProofType n _ ))) = n
               numDischarged (Just (PolyTypedProof m (ProofType n _))) = m * n

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/Montague.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/Montague.hs
@@ -7,6 +7,7 @@ import Data.Typeable
 import Data.List (findIndex)
 import Text.Parsec
 import Carnap.Core.Data.Types
+import Carnap.Calculi.Util
 import Carnap.Calculi.NaturalDeduction.Syntax
 import Carnap.Calculi.NaturalDeduction.Parser.Util
 import Carnap.Languages.ClassicalSequent.Syntax

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/StructuredFitch.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/StructuredFitch.hs
@@ -5,6 +5,7 @@ where
 import Data.Tree (Tree(Node))
 import Data.List (delete)
 import Data.Typeable
+import Carnap.Calculi.Util
 import Carnap.Calculi.NaturalDeduction.Syntax
 import Carnap.Languages.ClassicalSequent.Syntax
 

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Syntax.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Syntax.hs
@@ -296,8 +296,6 @@ doubleProof = TypedProof (ProofType 0 2)
 
 assumptiveProof = TypedProof (ProofType 1 1)
 
-type Restriction lex = [Equation (ClassicalSequentOver lex)] -> Maybe String
-
 type Restrictor r lex = Int -> r -> Maybe (Restriction lex)
 
 andFurtherRestriction f g sub = case f sub of 
@@ -320,8 +318,7 @@ class Inference r lex sem | r -> lex sem where
         restriction _ = Nothing
 
         --restrictions, based on given substitutions, whole derivation, and position in derivation
-        --XXX: the either here is a bit of a hack. Probably all deductions
-        --should be preprocessed into deduction trees.
+        --XXX: the either here is a bit of a hack
         globalRestriction :: Either (Deduction r lex sem) (DeductionTree r lex sem) -> Restrictor r lex
         globalRestriction _ _ _ = Nothing
         

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Syntax.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Syntax.hs
@@ -42,7 +42,7 @@ data DeductionLine r lex a where
             { dependAsserted :: FixLang lex a
             , dependAssertRule :: MultiRule r
             , dependAssertDependencies :: [(Int,Int)]
-            , dependAssertDischarged :: [Int]
+            , dependAssertDischarged :: Maybe [Int]
             , dependAssertInScope:: [Int]
             , dependAssertLineNo:: Maybe Int
             } -> DeductionLine r lex a
@@ -97,7 +97,7 @@ isPremiseLine _ = False
 inScope (DependentAssertLine _ _ _ _ s _) = s
 inScope _ = []
 
-discharged (DependentAssertLine _ _ _ d _ _) = d
+discharged (DependentAssertLine _ _ _ (Just d) _ _) = d
 discharged _ = []
 
 justificationOf (AssertLine _ r _ _) = Just r 
@@ -244,11 +244,11 @@ data LemmonVariant = StandardLemmon | TomassiStyle
 
 data FitchVariant = StandardFitch | BergmanMooreAndNelsonStyle
 
-type ProofMemoRef lex sem r = IORef (Map Int (Either (ProofErrorMessage lex) 
-                                                     ( ClassicalSequentOver lex (Sequent sem)
+type ProofMemoRef lex sem r = IORef (Map Int [Either (ProofErrorMessage lex) 
+                                                     [(ClassicalSequentOver lex (Sequent sem)
                                                      , [Equation (ClassicalSequentOver lex)]
-                                                     , r)
-                                           ))
+                                                     , r)]
+                                           ])
 
 data RuntimeNaturalDeductionConfig lex sem = RuntimeNaturalDeductionConfig
         { derivedRules :: Map String (ClassicalSequentOver lex (Sequent sem))

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Syntax.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Syntax.hs
@@ -13,6 +13,7 @@ import Carnap.Core.Unification.ACUI
 import Carnap.Core.Data.Types
 import Carnap.Core.Data.Classes
 import Carnap.Core.Data.Optics
+import Carnap.Calculi.Util
 import Carnap.Languages.PurePropositional.Syntax
 import Carnap.Languages.ClassicalSequent.Syntax
 import Carnap.Languages.ClassicalSequent.Parser
@@ -183,27 +184,9 @@ availableSubproof m sp@(SubProof r ls) = do loc <- locale m sp
 --  1.3 Error Messages  --
 --------------------------
 
-data ProofErrorMessage :: ((* -> *) -> * -> *) -> * where
-        NoParse :: ParseError -> Int -> ProofErrorMessage lex
-        NoUnify :: [[Equation (ClassicalSequentOver lex)]]  -> Int -> ProofErrorMessage lex
-        GenericError :: String -> Int -> ProofErrorMessage lex
-        NoResult :: Int -> ProofErrorMessage lex --meant for blanks
-
--- TODO These should be combined into a lens
-
-lineNoOfError (NoParse _ n) = n
-lineNoOfError (NoUnify _ n) = n
-lineNoOfError (GenericError _ n) = n
-lineNoOfError (NoResult n) = n
-
-renumber :: Int -> ProofErrorMessage lex -> ProofErrorMessage lex
-renumber m (NoParse x n) = NoParse x m
-renumber m (NoUnify x n) = NoUnify x m
-renumber m (GenericError s n) = GenericError s m
-renumber m (NoResult n) = NoResult m
 
 ------------------
---  1.4 Proofs  --
+--  1.3 Proofs  --
 ------------------
 
 data ProofLine r lex sem where 
@@ -236,7 +219,7 @@ instance Hashable a => Hashable (Tree a) where
         hashWithSalt k (Node x ts) = hashWithSalt k x `hashWithSalt` ts
 
 --------------------
---  1.5 Feedback  --
+--  1.4 Feedback  --
 --------------------
 
 type FeedbackLine lex sem = Either (ProofErrorMessage lex) (ClassicalSequentOver lex (Sequent sem))
@@ -250,7 +233,7 @@ type SequentTree lex sem = Tree (Int, ClassicalSequentOver lex (Sequent sem))
 --inference rules. 
 
 -------------------
---  1.6 Calculi  --
+--  1.5 Calculi  --
 -------------------
 --These are intended to wrap up a whole ND system, including some of its
 --superficial features like rendering.

--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Syntax.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Syntax.hs
@@ -332,7 +332,10 @@ class Inference r lex sem | r -> lex sem where
         isPremise = const False
         --TODO: template for error messages, etc.
 
-type SupportsND r lex sem = ( Show r , Typeable sem, ReLex lex 
+type SupportsND r lex sem = 
+    ( Show r 
+    , Typeable sem
+    , ReLex lex 
     , Inference r lex sem
     , Schematizable (lex (FixLang lex))
     , Schematizable (lex (ClassicalSequentOver lex))

--- a/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
@@ -2,6 +2,7 @@
 module Carnap.Calculi.Tableau.Checker where
 
 import Carnap.Core.Data.Types
+import Carnap.Core.Data.Classes
 import Carnap.Core.Data.Optics
 import Carnap.Core.Unification.Unification
 import Carnap.Core.Unification.ACUI
@@ -19,6 +20,10 @@ import Control.Lens
 validateTree :: 
     ( MonadVar (ClassicalSequentOver lex) (State Int)
     , FirstOrderLex (lex (ClassicalSequentOver lex))
+    , FirstOrderLex (lex (FixLang lex))
+    , Schematizable (lex (ClassicalSequentOver lex))
+    , CopulaSchema (ClassicalSequentOver lex)
+    , BoundVars lex
     , PrismLink (lex (ClassicalSequentOver lex)) (SubstitutionalVariable (ClassicalSequentOver lex)) -- XXX Not needed in GHC >= 8.4
     , Typeable sem
     , Sequentable lex
@@ -30,11 +35,16 @@ validateTree (Node n descendents) = Node (clean $ validateNode n theChildren) (m
     where theChildren = map rootLabel descendents
           clean (Correct:_) = Correct
           clean [Feedback s] = Feedback s
+          clean (Feedback _ :xs) = clean xs
           clean [] = error "no feedback"
 
 validateNode ::
     ( MonadVar (ClassicalSequentOver lex) (State Int)
     , FirstOrderLex (lex (ClassicalSequentOver lex))
+    , FirstOrderLex (lex (FixLang lex))
+    , Schematizable (lex (ClassicalSequentOver lex))
+    , CopulaSchema (ClassicalSequentOver lex)
+    , BoundVars lex
     , PrismLink (lex (ClassicalSequentOver lex)) (SubstitutionalVariable (ClassicalSequentOver lex)) -- XXX Not needed in GHC >= 8.4
     , Typeable sem
     , Sequentable lex
@@ -44,8 +54,10 @@ validateNode ::
     ) => TableauNode lex sem rule -> [TableauNode lex sem rule] -> [TreeFeedbackNode]
 validateNode n ns = case tableauNodeRule n of
                         Nothing -> return $ Feedback "no rule developing this node"
-                        Just r -> case hosolve [(liftToSequent  . tableauNodeTarget $ n) :=: (liftToSequent . schemeTarget . coreRuleOf $ r)] of
-                            Left (NoUnify _ _) -> return $ Feedback "Rule applied incorrectly to node" --TODO Improve feedback here
+                        Just r -> case hosolve [(liftToSequent . schemeTarget . coreRuleOf $ r) :=: (liftToSequent  . tableauNodeTarget $ n)] of
+                            Left (NoUnify _ _) -> return $ 
+                                Feedback $ "Rule applied incorrectly to node: cannot unify " 
+                                        ++ show [(liftToSequent . schemeTarget . coreRuleOf $ r) :=: (liftToSequent  . tableauNodeTarget $ n)]
                             Right subs -> do
                                 sub <- subs
                                 case coreRestriction r >>= ($ sub) of
@@ -53,19 +65,28 @@ validateNode n ns = case tableauNodeRule n of
                                     Nothing -> do
                                       childSeqs <- permutations (map tableauNodeSeq ns)
                                       let theRule = coreRuleOf r
-                                          subbedChildren = map (applySub sub) (upperSequents theRule)
-                                          subbedParent = applySub sub (lowerSequent theRule)
-                                          prob = (subbedParent :=: tableauNodeSeq n) : zipWith (:=:) subbedChildren childSeqs
+                                          subbedChildrenLHS = map (view lhs . applySub sub) (upperSequents theRule)
+                                          subbedChildrenRHS = map (view rhs . applySub sub) (upperSequents theRule)
+                                          subbedParentLHS = view lhs . applySub sub $ lowerSequent theRule
+                                          subbedParentRHS = view rhs . applySub sub $ lowerSequent theRule
+                                          prob = (subbedParentLHS :=: (view lhs . tableauNodeSeq $ n)) 
+                                               : (subbedParentRHS :=: (view rhs . tableauNodeSeq $ n))
+                                               : zipWith (:=:) subbedChildrenLHS (map (view lhs) childSeqs)
+                                               ++ zipWith (:=:) subbedChildrenRHS (map (view rhs) childSeqs)
                                       case acuisolve prob of
-                                          Left (NoUnify _ _) -> return $ Feedback "Rule applied incorrectly to branch" --TODO Improve feedback here.
+                                          Left (NoUnify _ _) -> return $ 
+                                            Feedback $ "Rule applied incorrectly to branch, cannot solve"
+                                                    ++ show prob
                                           Right subs -> return Correct
 
 schemeTarget :: 
     ( FirstOrder (ClassicalSequentOver lex)
+    , FirstOrderLex (lex (FixLang lex))
     , Typeable sem
     , Sequentable lex
+    , BoundVars lex
     , PrismSubstitutionalVariable lex
     ) => SequentRule lex sem -> FixLang lex sem
-schemeTarget r = case filter isVar . toListOf concretes . lowerSequent $ r of
+schemeTarget r = case filter (any isVar . universe . fromSequent) . toListOf concretes . lowerSequent $ r of
                  [f] -> fromSequent f
-                 _ -> error $ "rule lacks a unique target"
+                 cs -> error $ "rule lacks a unique target. " ++ (show (length cs)) ++ " Possible targets."

--- a/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
@@ -54,30 +54,48 @@ validateNode ::
     ) => TableauNode lex sem rule -> [TableauNode lex sem rule] -> [TreeFeedbackNode]
 validateNode n ns = case tableauNodeRule n of
                         Nothing -> return $ Feedback "no rule developing this node"
-                        Just r -> case hosolve [(liftToSequent . schemeTarget . coreRuleOf $ r) :=: (liftToSequent  . tableauNodeTarget $ n)] of
-                            Left (NoUnify _ _) -> return $ 
-                                Feedback $ "Rule applied incorrectly to node: cannot unify " 
-                                        ++ show [(liftToSequent . schemeTarget . coreRuleOf $ r) :=: (liftToSequent  . tableauNodeTarget $ n)]
-                            Right subs -> do
-                                sub <- subs
-                                case coreRestriction r >>= ($ sub) of
-                                    Just msg -> return $ Feedback msg
-                                    Nothing -> do
-                                      childSeqs <- permutations (map tableauNodeSeq ns)
-                                      let theRule = coreRuleOf r
-                                          subbedChildrenLHS = map (view lhs . applySub sub) (upperSequents theRule)
-                                          subbedChildrenRHS = map (view rhs . applySub sub) (upperSequents theRule)
-                                          subbedParentLHS = view lhs . applySub sub $ lowerSequent theRule
-                                          subbedParentRHS = view rhs . applySub sub $ lowerSequent theRule
-                                          prob = (subbedParentLHS :=: (view lhs . tableauNodeSeq $ n)) 
-                                               : (subbedParentRHS :=: (view rhs . tableauNodeSeq $ n))
-                                               : zipWith (:=:) subbedChildrenLHS (map (view lhs) childSeqs)
-                                               ++ zipWith (:=:) subbedChildrenRHS (map (view rhs) childSeqs)
-                                      case acuisolve prob of
-                                          Left (NoUnify _ _) -> return $ 
-                                            Feedback $ "Rule applied incorrectly to branch, cannot solve"
-                                                    ++ show prob
-                                          Right subs -> return Correct
+                        Just r -> let theTarget = schemeTarget . coreRuleOf $ r
+                                      mainProb = [(getTarget theTarget) :=: (nodeTarget theTarget n)] in
+                            case hosolve mainProb of
+                                Left (NoUnify _ _) -> return $ 
+                                    Feedback $ "Rule applied incorrectly to node: cannot unify " 
+                                            ++ unlines (map show mainProb)
+                                Right subs -> do
+                                    sub <- subs
+                                    case coreRestriction r >>= ($ sub) of
+                                        Just msg -> return $ Feedback msg
+                                        Nothing -> do
+                                          childSeqs <- permutations (map tableauNodeSeq ns)
+                                          let theRule = coreRuleOf r
+                                              subbedChildrenLHS = map (view lhs . applySub sub) (upperSequents theRule)
+                                              subbedChildrenRHS = map (view rhs . applySub sub) (upperSequents theRule)
+                                              subbedParentLHS = view lhs . applySub sub $ lowerSequent theRule
+                                              subbedParentRHS = view rhs . applySub sub $ lowerSequent theRule
+                                              prob = (subbedParentLHS :=: (view lhs . tableauNodeSeq $ n)) 
+                                                   : (subbedParentRHS :=: (view rhs . tableauNodeSeq $ n))
+                                                   : zipWith (:=:) subbedChildrenLHS (map (view lhs) childSeqs)
+                                                   ++ zipWith (:=:) subbedChildrenRHS (map (view rhs) childSeqs)
+                                          case acuisolve prob of
+                                              Left (NoUnify _ _) -> return $ 
+                                                Feedback $ "Rule applied incorrectly to branch, cannot solve:\n\n"
+                                                        ++ unlines (map show prob) 
+                                              Right subs -> return Correct
+
+nodeTarget :: 
+    ( FirstOrder (ClassicalSequentOver lex)
+    , FirstOrderLex (lex (FixLang lex))
+    , Typeable sem
+    , Sequentable lex
+    , BoundVars lex
+    , PrismSubstitutionalVariable lex
+    ) => SequentRuleTarget (ClassicalSequentLexOver lex) sem -> TableauNode lex sem rule -> ClassicalSequentOver lex sem
+nodeTarget t n = case tableauNodeTarget n of
+                     Just f -> liftToSequent f
+                     Nothing -> case t of
+                                    --head and last are reversed because `concretes` reverses order, I think
+                                    RightConc _ -> head . toListOf concretes . view rhs . tableauNodeSeq $ n
+                                    LeftConc _ -> last . toListOf concretes . view lhs . tableauNodeSeq $ n
+                                    _ -> error "bad nodeTarget location"
 
 schemeTarget :: 
     ( FirstOrder (ClassicalSequentOver lex)
@@ -86,7 +104,20 @@ schemeTarget ::
     , Sequentable lex
     , BoundVars lex
     , PrismSubstitutionalVariable lex
-    ) => SequentRule lex sem -> FixLang lex sem
-schemeTarget r = case filter (any isVar . universe . fromSequent) . toListOf concretes . lowerSequent $ r of
-                 (f:_) -> fromSequent f
-                 [] -> error $ "rule lacks a target."
+    ) => SequentRule lex sem -> SequentRuleTarget (ClassicalSequentLexOver lex) sem
+schemeTarget r = case ( filter (any isVar . universe . fromSequent) . toListOf concretes . view lhs . lowerSequent $ r
+                      , filter (any isVar . universe . fromSequent) . toListOf concretes . view rhs . lowerSequent $ r
+                      ) of (f:_,_) -> LeftConc f
+                           (_,f:_) -> RightConc f
+                           _ -> error $ "rule lacks a target."
+
+data SequentRuleTarget lex sem = LeftConc (FixLang lex sem) 
+                               | RightConc (FixLang lex sem) 
+                               | LeftPrem Int (FixLang lex sem)
+                               | RightPrem Int (FixLang lex sem)
+                               | NoTarget
+
+getTarget (LeftConc f) = f
+getTarget (RightConc f) = f
+getTarget (LeftPrem _ f) = f
+getTarget (RightPrem _ f) = f

--- a/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
@@ -1,0 +1,61 @@
+{-#LANGUAGE FlexibleContexts #-}
+module Carnap.Calculi.Tableau.Checker where
+
+import Carnap.Core.Data.Types
+import Carnap.Core.Data.Optics
+import Carnap.Core.Unification.Unification
+import Carnap.Core.Unification.ACUI
+import Carnap.Calculi.Util
+import Carnap.Calculi.Tableau.Data
+import Carnap.Languages.ClassicalSequent.Syntax
+import Data.Tree
+import Data.List
+import Data.Typeable
+import Control.Monad.State
+
+--This function should swap out the contents of each node in a tableau for
+--appropriate feedback, or an indication that the node is correct.
+validateTree :: 
+    ( MonadVar (ClassicalSequentOver lex) (State Int)
+    , FirstOrderLex (lex (ClassicalSequentOver lex))
+    , Typeable sem
+    , Sequentable lex
+    , PrismSubstitutionalVariable lex
+    , EtaExpand (ClassicalSequentOver lex) sem
+    ) => Tableau lex sem rule -> TreeFeedback
+validateTree (Node n descendents) = Node (clean $ validateNode n theChildren) (map validateTree descendents)
+    where theChildren = map rootLabel descendents
+          clean (Correct:_) = Correct
+          clean [Feedback s] = Feedback s
+          clean [] = error "no feedback"
+
+--TODO : catch eigenvariable errors in nodes
+validateNode ::
+    ( MonadVar (ClassicalSequentOver lex) (State Int)
+    , FirstOrderLex (lex (ClassicalSequentOver lex))
+    , Typeable sem
+    , Sequentable lex
+    , PrismSubstitutionalVariable lex
+    , EtaExpand (ClassicalSequentOver lex) sem
+    ) => TableauNode lex sem rule -> [TableauNode lex sem rule] -> [TreeFeedbackNode]
+validateNode n ns = case hosolve [seqTarget n :=: seqRuleTarget n] of
+                        Left (NoUnify _ _) -> return $ Feedback "Rule applied incorrectly to node" --TODO Improve feedback here
+                        Right subs -> do sub <- subs
+                                         childSeqs <- permutations (map tableauNodeSeq ns)
+                                         let subbedChildren = map (applySub sub) (ruleChildren theRule)
+                                             subbedParent = applySub sub (ruleParent theRule)
+                                             prob = (subbedParent :=: tableauNodeSeq n) : zipWith (:=:) subbedChildren childSeqs
+                                         case acuisolve prob of
+                                             Left (NoUnify _ _) -> return $ Feedback "Rule applied incorrectly to branch" --TODO Improve feedback here.
+                                             Right subs -> return Correct
+    where theRule = tableauNodeRule n
+          seqTarget :: Sequentable lex => TableauNode lex sem rule -> ClassicalSequentOver lex sem
+          seqTarget = liftToSequent . tableauNodeTarget
+          seqRuleTarget :: Sequentable lex => TableauNode lex sem rule -> ClassicalSequentOver lex sem
+          seqRuleTarget = liftToSequent . ruleTarget . tableauNodeRule
+
+ruleTarget = undefined
+
+ruleParent = undefined
+
+ruleChildren = undefined

--- a/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
@@ -21,7 +21,7 @@ validateTree ::
     ( MonadVar (ClassicalSequentOver lex) (State Int)
     , FirstOrderLex (lex (ClassicalSequentOver lex))
     , FirstOrderLex (lex (FixLang lex))
-    , Eq (ClassicalSequentOver lex sem)
+    , Eq (FixLang lex sem)
     , Schematizable (lex (ClassicalSequentOver lex))
     , CopulaSchema (ClassicalSequentOver lex)
     , BoundVars lex
@@ -43,7 +43,7 @@ validateNode ::
     ( MonadVar (ClassicalSequentOver lex) (State Int)
     , FirstOrderLex (lex (ClassicalSequentOver lex))
     , FirstOrderLex (lex (FixLang lex))
-    , Eq (ClassicalSequentOver lex sem)
+    , Eq (FixLang lex sem)
     , Schematizable (lex (ClassicalSequentOver lex))
     , CopulaSchema (ClassicalSequentOver lex)
     , BoundVars lex
@@ -63,12 +63,12 @@ validateNode n ns = case tableauNodeRule n of
                                else do
                                    ns' <- permutations ns
                                    let childSeqs = map tableauNodeSeq ns'
-                                       mainProb = case schemeTarget theRule of
+                                       mainProb = concatMap (\t -> case t of
                                           NoTarget -> []
                                           RightPrem n f -> [f :=: nodeTargetRight (ns' !! n)]
                                           LeftPrem n f -> [f :=: nodeTargetLeft (ns' !! n)]
                                           LeftConc f -> [f :=: nodeTargetLeft n]
-                                          RightConc f -> [f :=: nodeTargetRight n]
+                                          RightConc f -> [f :=: nodeTargetRight n]) (schemeTargets theRule)
                                    case hosolve mainProb of
                                         Left (NoUnify _ _) -> return $ 
                                             Feedback $ "Rule applied incorrectly to node: cannot unify\n\n " 

--- a/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
@@ -37,7 +37,7 @@ validateTree (Node n descendents) = Node (clean $ validateNode n theChildren) (m
           clean (Correct:_) = Correct
           clean [Feedback s] = Feedback s
           clean (Feedback _ :xs) = clean xs
-          clean [] = error "no feedback"
+          clean [] = Feedback "no feedback"
 
 validateNode ::
     ( MonadVar (ClassicalSequentOver lex) (State Int)
@@ -57,39 +57,41 @@ validateNode ::
 validateNode n ns = case tableauNodeRule n of
                         Nothing -> return $ Feedback "no rule developing this node"
                         Just r -> 
-                            do let theTarget = schemeTarget . coreRuleOf $ r
-                               ns' <- permutations ns
-                               let childSeqs = map tableauNodeSeq ns'
-                                   mainProb = case theTarget of
-                                      NoTarget -> []
-                                      RightPrem n f -> [f :=: nodeTargetRight (ns' !! n)]
-                                      LeftPrem n f -> [f :=: nodeTargetLeft (ns' !! n)]
-                                      LeftConc f -> [f :=: nodeTargetLeft n]
-                                      RightConc f -> [f :=: nodeTargetRight n]
-                               case hosolve mainProb of
-                                    Left (NoUnify _ _) -> return $ 
-                                        Feedback $ "Rule applied incorrectly to node: cannot unify " 
-                                                ++ unlines (map show mainProb)
-                                    Right subs -> do
-                                        sub <- subs
-                                        case coreRestriction r >>= ($ sub) of
-                                            Just msg -> return $ Feedback msg
-                                            Nothing -> do
-                                              childSeqs <- permutations (map tableauNodeSeq ns)
-                                              let theRule = coreRuleOf r
-                                                  subbedChildrenLHS = map (view lhs . applySub sub) (upperSequents theRule)
-                                                  subbedChildrenRHS = map (view rhs . applySub sub) (upperSequents theRule)
-                                                  subbedParentLHS = view lhs . applySub sub $ lowerSequent theRule
-                                                  subbedParentRHS = view rhs . applySub sub $ lowerSequent theRule
-                                                  prob = (subbedParentLHS :=: (view lhs . tableauNodeSeq $ n)) 
-                                                       : (subbedParentRHS :=: (view rhs . tableauNodeSeq $ n))
-                                                       : zipWith (:=:) subbedChildrenLHS (map (view lhs) childSeqs)
-                                                       ++ zipWith (:=:) subbedChildrenRHS (map (view rhs) childSeqs)
-                                              case acuisolve prob of
-                                                  Left (NoUnify _ _) -> return $ 
-                                                    Feedback $ "Rule applied incorrectly to branch, cannot solve:\n\n"
-                                                            ++ unlines (map show prob) 
-                                                  Right subs -> return Correct
+                            do let theRule = coreRuleOf r
+                               if length (upperSequents theRule) /= length ns 
+                               then return $ Feedback "wrong number of premises"
+                               else do
+                                   ns' <- permutations ns
+                                   let childSeqs = map tableauNodeSeq ns'
+                                       mainProb = case schemeTarget theRule of
+                                          NoTarget -> []
+                                          RightPrem n f -> [f :=: nodeTargetRight (ns' !! n)]
+                                          LeftPrem n f -> [f :=: nodeTargetLeft (ns' !! n)]
+                                          LeftConc f -> [f :=: nodeTargetLeft n]
+                                          RightConc f -> [f :=: nodeTargetRight n]
+                                   case hosolve mainProb of
+                                        Left (NoUnify _ _) -> return $ 
+                                            Feedback $ "Rule applied incorrectly to node: cannot unify\n\n " 
+                                                    ++ unlines (map show mainProb)
+                                        Right subs -> do
+                                            sub <- subs
+                                            case coreRestriction r >>= ($ sub) of
+                                                Just msg -> return $ Feedback msg
+                                                Nothing -> do
+                                                  childSeqs <- permutations (map tableauNodeSeq ns)
+                                                  let subbedChildrenLHS = map (view lhs . applySub sub) (upperSequents theRule)
+                                                      subbedChildrenRHS = map (view rhs . applySub sub) (upperSequents theRule)
+                                                      subbedParentLHS = view lhs . applySub sub $ lowerSequent theRule
+                                                      subbedParentRHS = view rhs . applySub sub $ lowerSequent theRule
+                                                      prob = (subbedParentLHS :=: (view lhs . tableauNodeSeq $ n)) 
+                                                           : (subbedParentRHS :=: (view rhs . tableauNodeSeq $ n))
+                                                           : zipWith (:=:) subbedChildrenLHS (map (view lhs) childSeqs)
+                                                           ++ zipWith (:=:) subbedChildrenRHS (map (view rhs) childSeqs)
+                                                  case acuisolve prob of
+                                                      Left (NoUnify _ _) -> return $ 
+                                                        Feedback $ "Rule applied incorrectly to branch, cannot solve:\n\n"
+                                                                ++ unlines (map show prob) 
+                                                      Right subs -> return Correct
 
 nodeTargetLeft, nodeTargetRight :: 
     ( FirstOrder (ClassicalSequentOver lex)
@@ -107,7 +109,6 @@ nodeTargetRight n = case tableauNodeTarget n of
                      Nothing -> head . toListOf concretes . view rhs . tableauNodeSeq $ n
   --head and last are reversed because `concretes` reverses order, I think
 
---TODO: Should actually extract a list of irredundant targets
 schemeTarget :: 
     ( FirstOrder (ClassicalSequentOver lex)
     , Eq (ClassicalSequentOver lex sem)
@@ -118,18 +119,40 @@ schemeTarget ::
     , PrismSubstitutionalVariable lex
     ) => SequentRule lex sem -> SequentRuleTarget (ClassicalSequentLexOver lex) sem
 schemeTarget r = case getTarget (lowerSequent r) of 
-                    NoTarget -> case filter (\(_,x) -> x /= NoTarget) . map (\(n,x) -> (n,getTarget x)) . zip [1..] $ upperSequents r of
+                    NoTarget -> case filter (\(_,x) -> x /= NoTarget) . map (\(n,x) -> (n,getTarget x)) . zip [0..] $ upperSequents r of
                                        [] -> NoTarget
                                        ((n,LeftConc f):_) -> LeftPrem n f
                                        ((n,RightConc f):_) -> RightPrem n f
                     target -> target
-    where getTarget seq = 
-            case ( filter (any isVar . universe . fromSequent) . toListOf concretes . view lhs $ seq
-                 , filter (any isVar . universe . fromSequent) . toListOf concretes . view rhs $ seq
-                 ) of (f:_,_) -> LeftConc f
-                      (_,f:_) -> RightConc f
-                      _ -> NoTarget
 
+schemeTargets :: 
+    ( FirstOrder (ClassicalSequentOver lex)
+    , Eq (FixLang lex sem)
+    , FirstOrderLex (lex (FixLang lex))
+    , Typeable sem
+    , Sequentable lex
+    , BoundVars lex
+    , PrismSubstitutionalVariable lex
+    ) => SequentRule lex sem -> [SequentRuleTarget (ClassicalSequentLexOver lex) sem]
+schemeTargets r = redundant targetList []
+    where targetList = getTarget (lowerSequent r) : map retarget (zip [0 ..] (map getTarget $ upperSequents r))
+          retarget (n,LeftConc f) = LeftPrem n f
+          retarget (n,RightConc f) = RightPrem n f
+          redundant [] accum = accum
+          redundant (NoTarget:potential) accum = redundant potential accum
+          redundant (p:potential) accum | any (subform p) accum = redundant potential accum
+                                        | otherwise = redundant potential  $ p : (filter (not . flip subform p) accum)
+          subform x y = (targetContent x) `elem` universe (targetContent y)
+          targetContent (LeftConc f) = fromSequent f
+          targetContent (RightConc f) = fromSequent f
+          targetContent (LeftPrem _ f) = fromSequent f
+          targetContent (RightPrem _ f) = fromSequent f
+
+getTarget seq = case ( filter (any isVar . universe . fromSequent) . toListOf concretes . view lhs $ seq
+             , filter (any isVar . universe . fromSequent) . toListOf concretes . view rhs $ seq
+             ) of (f:_,_) -> LeftConc f
+                  (_,f:_) -> RightConc f
+                  _ -> NoTarget
 
 data SequentRuleTarget lex sem = LeftConc (FixLang lex sem) 
                                | RightConc (FixLang lex sem) 

--- a/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
@@ -88,5 +88,5 @@ schemeTarget ::
     , PrismSubstitutionalVariable lex
     ) => SequentRule lex sem -> FixLang lex sem
 schemeTarget r = case filter (any isVar . universe . fromSequent) . toListOf concretes . lowerSequent $ r of
-                 [f] -> fromSequent f
-                 cs -> error $ "rule lacks a unique target. " ++ (show (length cs)) ++ " Possible targets."
+                 (f:_) -> fromSequent f
+                 [] -> error $ "rule lacks a target."

--- a/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
@@ -138,6 +138,7 @@ schemeTargets r = redundant targetList []
     where targetList = getTarget (lowerSequent r) : map retarget (zip [0 ..] (map getTarget $ upperSequents r))
           retarget (n,LeftConc f) = LeftPrem n f
           retarget (n,RightConc f) = RightPrem n f
+          retarget (_,NoTarget) = NoTarget
           redundant [] accum = accum
           redundant (NoTarget:potential) accum = redundant potential accum
           redundant (p:potential) accum | any (subform p) accum = redundant potential accum

--- a/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
@@ -38,7 +38,7 @@ validateTree (Node n descendents) = Node (clean $ validateNode n theChildren) (m
           clean (Correct:_) = Correct
           clean [Feedback s] = Feedback s
           clean (Feedback _ :xs) = clean xs
-          clean [] = Feedback "no feedback"
+          clean _ = Feedback "no feedback"
 
 validateNode ::
     ( MonadVar (ClassicalSequentOver lex) (State Int)

--- a/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
@@ -12,6 +12,7 @@ import Data.Tree
 import Data.List
 import Data.Typeable
 import Control.Monad.State
+import Control.Lens
 
 --This function should swap out the contents of each node in a tableau for
 --appropriate feedback, or an indication that the node is correct.
@@ -42,20 +43,34 @@ validateNode n ns = case hosolve [seqTarget n :=: seqRuleTarget n] of
                         Left (NoUnify _ _) -> return $ Feedback "Rule applied incorrectly to node" --TODO Improve feedback here
                         Right subs -> do sub <- subs
                                          childSeqs <- permutations (map tableauNodeSeq ns)
-                                         let subbedChildren = map (applySub sub) (ruleChildren theRule)
-                                             subbedParent = applySub sub (ruleParent theRule)
+                                         let subbedChildren = map (applySub sub) (upperSequents theRule)
+                                             subbedParent = applySub sub (lowerSequent theRule)
                                              prob = (subbedParent :=: tableauNodeSeq n) : zipWith (:=:) subbedChildren childSeqs
                                          case acuisolve prob of
                                              Left (NoUnify _ _) -> return $ Feedback "Rule applied incorrectly to branch" --TODO Improve feedback here.
                                              Right subs -> return Correct
-    where theRule = tableauNodeRule n
+    where theRule = schemeOf . tableauNodeRule $ n
           seqTarget :: Sequentable lex => TableauNode lex sem rule -> ClassicalSequentOver lex sem
           seqTarget = liftToSequent . tableauNodeTarget
-          seqRuleTarget :: Sequentable lex => TableauNode lex sem rule -> ClassicalSequentOver lex sem
-          seqRuleTarget = liftToSequent . ruleTarget . tableauNodeRule
+          seqRuleTarget :: 
+            ( Sequentable lex
+            , PrismSubstitutionalVariable lex
+            , FirstOrder (ClassicalSequentOver lex)
+            , Typeable sem
+            ) => TableauNode lex sem rule -> ClassicalSequentOver lex sem
+          seqRuleTarget = liftToSequent . schemeTarget . schemeOf . tableauNodeRule
 
-ruleTarget = undefined
+schemeTarget :: 
+    ( FirstOrder (ClassicalSequentOver lex)
+    , Typeable sem
+    , Sequentable lex
+    , PrismSubstitutionalVariable lex
+    ) => SequentRule lex sem -> FixLang lex sem
+schemeTarget r = case filter isVar . toListOf concretes . lowerSequent $ r of
+                 [f] -> fromSequent f
+                 _ -> error $ "rule lacks a unique target"
 
-ruleParent = undefined
+schemeOf = undefined
 
 ruleChildren = undefined
+

--- a/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Checker.hs
@@ -19,8 +19,10 @@ import Control.Lens
 validateTree :: 
     ( MonadVar (ClassicalSequentOver lex) (State Int)
     , FirstOrderLex (lex (ClassicalSequentOver lex))
+    , PrismLink (lex (ClassicalSequentOver lex)) (SubstitutionalVariable (ClassicalSequentOver lex)) -- XXX Not needed in GHC >= 8.4
     , Typeable sem
     , Sequentable lex
+    , CoreInference rule lex sem
     , PrismSubstitutionalVariable lex
     , EtaExpand (ClassicalSequentOver lex) sem
     ) => Tableau lex sem rule -> TreeFeedback
@@ -30,35 +32,33 @@ validateTree (Node n descendents) = Node (clean $ validateNode n theChildren) (m
           clean [Feedback s] = Feedback s
           clean [] = error "no feedback"
 
---TODO : catch eigenvariable errors in nodes
 validateNode ::
     ( MonadVar (ClassicalSequentOver lex) (State Int)
     , FirstOrderLex (lex (ClassicalSequentOver lex))
+    , PrismLink (lex (ClassicalSequentOver lex)) (SubstitutionalVariable (ClassicalSequentOver lex)) -- XXX Not needed in GHC >= 8.4
     , Typeable sem
     , Sequentable lex
+    , CoreInference rule lex sem
     , PrismSubstitutionalVariable lex
     , EtaExpand (ClassicalSequentOver lex) sem
     ) => TableauNode lex sem rule -> [TableauNode lex sem rule] -> [TreeFeedbackNode]
-validateNode n ns = case hosolve [seqTarget n :=: seqRuleTarget n] of
-                        Left (NoUnify _ _) -> return $ Feedback "Rule applied incorrectly to node" --TODO Improve feedback here
-                        Right subs -> do sub <- subs
-                                         childSeqs <- permutations (map tableauNodeSeq ns)
-                                         let subbedChildren = map (applySub sub) (upperSequents theRule)
-                                             subbedParent = applySub sub (lowerSequent theRule)
-                                             prob = (subbedParent :=: tableauNodeSeq n) : zipWith (:=:) subbedChildren childSeqs
-                                         case acuisolve prob of
-                                             Left (NoUnify _ _) -> return $ Feedback "Rule applied incorrectly to branch" --TODO Improve feedback here.
-                                             Right subs -> return Correct
-    where theRule = schemeOf . tableauNodeRule $ n
-          seqTarget :: Sequentable lex => TableauNode lex sem rule -> ClassicalSequentOver lex sem
-          seqTarget = liftToSequent . tableauNodeTarget
-          seqRuleTarget :: 
-            ( Sequentable lex
-            , PrismSubstitutionalVariable lex
-            , FirstOrder (ClassicalSequentOver lex)
-            , Typeable sem
-            ) => TableauNode lex sem rule -> ClassicalSequentOver lex sem
-          seqRuleTarget = liftToSequent . schemeTarget . schemeOf . tableauNodeRule
+validateNode n ns = case tableauNodeRule n of
+                        Nothing -> return $ Feedback "no rule developing this node"
+                        Just r -> case hosolve [(liftToSequent  . tableauNodeTarget $ n) :=: (liftToSequent . schemeTarget . coreRuleOf $ r)] of
+                            Left (NoUnify _ _) -> return $ Feedback "Rule applied incorrectly to node" --TODO Improve feedback here
+                            Right subs -> do
+                                sub <- subs
+                                case coreRestriction r >>= ($ sub) of
+                                    Just msg -> return $ Feedback msg
+                                    Nothing -> do
+                                      childSeqs <- permutations (map tableauNodeSeq ns)
+                                      let theRule = coreRuleOf r
+                                          subbedChildren = map (applySub sub) (upperSequents theRule)
+                                          subbedParent = applySub sub (lowerSequent theRule)
+                                          prob = (subbedParent :=: tableauNodeSeq n) : zipWith (:=:) subbedChildren childSeqs
+                                      case acuisolve prob of
+                                          Left (NoUnify _ _) -> return $ Feedback "Rule applied incorrectly to branch" --TODO Improve feedback here.
+                                          Right subs -> return Correct
 
 schemeTarget :: 
     ( FirstOrder (ClassicalSequentOver lex)
@@ -69,8 +69,3 @@ schemeTarget ::
 schemeTarget r = case filter isVar . toListOf concretes . lowerSequent $ r of
                  [f] -> fromSequent f
                  _ -> error $ "rule lacks a unique target"
-
-schemeOf = undefined
-
-ruleChildren = undefined
-

--- a/Carnap/src/Carnap/Calculi/Tableau/Data.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Data.hs
@@ -36,7 +36,7 @@ type Tableau lex sem rule = Tree (TableauNode lex sem rule)
 
 data TreeFeedbackNode = Correct | Feedback String
 
-data TreeFeedback = Tree TreeFeedbackNode
+type TreeFeedback = Tree TreeFeedbackNode
 
 data TaubleauCalc lex sem rule = TableauCalc 
            { tbParseForm :: Parsec String () (FixLang lex sem)

--- a/Carnap/src/Carnap/Calculi/Tableau/Data.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Data.hs
@@ -1,0 +1,39 @@
+module Carnap.Calculi.Tableau.Data where
+
+import Carnap.Core.Data.Types
+import Carnap.Languages.ClassicalSequent.Syntax
+import Data.Tree
+import Text.Parsec
+
+data TaubleauCalc lex sem rule = TableauCalc 
+           { tbParseForm :: Parsec String () (FixLang lex sem)
+           , tbParseRule :: Parsec String () rule
+           --possibly some other stuff here
+           }
+
+--a TreeForm is a formula within a truth tree, labeled by its row and whether it is resolved.
+data TreeForm lex sem = TreeForm
+           { treeForm :: FixLang lex sem
+           , treeFormRow :: Int
+           , treeFormResolved :: Bool
+           }
+
+
+--A tree node is a node in a truth tree, labeled by the rule used to create it.
+data TreeNode lex sem rule = TreeNode 
+           { treeNodeForms :: [TreeForm lex sem] 
+           , treeNodeRule :: Maybe rule
+           }
+
+
+--A truth tree is a rose tree of TreeNodes.
+type TruthTree lex sem rule = Tree (TreeNode lex sem rule)
+
+data TableauNode lex sem rule = TableauNode
+           { tableauNodeSeq :: ClassicalSequentOver lex (Sequent sem)
+           , tableauNodeTarget :: FixLang lex sem
+           , tableauNodeRule :: Maybe rule
+           --this is the rule that develops the node, not the rule that the node is developed by.
+           }
+
+type Tableau lex sem rule = Tree (TableauNode lex sem rule)

--- a/Carnap/src/Carnap/Calculi/Tableau/Data.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Data.hs
@@ -34,7 +34,7 @@ data TableauNode lex sem rule = TableauNode
 
 type Tableau lex sem rule = Tree (TableauNode lex sem rule)
 
-data TreeFeedbackNode = Correct | Feedback String
+data TreeFeedbackNode = Correct | Feedback String | Waiting | ParseErrorMsg String 
 
 type TreeFeedback = Tree TreeFeedbackNode
 

--- a/Carnap/src/Carnap/Calculi/Tableau/Data.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Data.hs
@@ -35,6 +35,7 @@ data TableauNode lex sem rule = TableauNode
 type Tableau lex sem rule = Tree (TableauNode lex sem rule)
 
 data TreeFeedbackNode = Correct | Feedback String | Waiting | ParseErrorMsg String 
+    deriving (Eq)
 
 type TreeFeedback = Tree TreeFeedbackNode
 

--- a/Carnap/src/Carnap/Calculi/Tableau/Data.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Data.hs
@@ -38,7 +38,7 @@ data TreeFeedbackNode = Correct | Feedback String
 
 type TreeFeedback = Tree TreeFeedbackNode
 
-data TaubleauCalc lex sem rule = TableauCalc 
+data TableauCalc lex sem rule = TableauCalc 
            { tbParseForm :: Parsec String () (FixLang lex sem)
            , tbParseRule :: Parsec String () rule
            --possibly some other stuff here

--- a/Carnap/src/Carnap/Calculi/Tableau/Data.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Data.hs
@@ -27,7 +27,7 @@ type TruthTree lex sem rule = Tree (TreeNode lex sem rule)
 
 data TableauNode lex sem rule = TableauNode
            { tableauNodeSeq :: ClassicalSequentOver lex (Sequent sem)
-           , tableauNodeTarget :: FixLang lex sem
+           , tableauNodeTarget :: Maybe (FixLang lex sem)
            , tableauNodeRule :: Maybe rule
            --this is the rule that develops the node, not the rule that the node is developed by.
            }

--- a/Carnap/src/Carnap/Calculi/Tableau/Data.hs
+++ b/Carnap/src/Carnap/Calculi/Tableau/Data.hs
@@ -5,11 +5,7 @@ import Carnap.Languages.ClassicalSequent.Syntax
 import Data.Tree
 import Text.Parsec
 
-data TaubleauCalc lex sem rule = TableauCalc 
-           { tbParseForm :: Parsec String () (FixLang lex sem)
-           , tbParseRule :: Parsec String () rule
-           --possibly some other stuff here
-           }
+
 
 --a TreeForm is a formula within a truth tree, labeled by its row and whether it is resolved.
 data TreeForm lex sem = TreeForm
@@ -37,3 +33,13 @@ data TableauNode lex sem rule = TableauNode
            }
 
 type Tableau lex sem rule = Tree (TableauNode lex sem rule)
+
+data TreeFeedbackNode = Correct | Feedback String
+
+data TreeFeedback = Tree TreeFeedbackNode
+
+data TaubleauCalc lex sem rule = TableauCalc 
+           { tbParseForm :: Parsec String () (FixLang lex sem)
+           , tbParseRule :: Parsec String () rule
+           --possibly some other stuff here
+           }

--- a/Carnap/src/Carnap/Calculi/Util.hs
+++ b/Carnap/src/Carnap/Calculi/Util.hs
@@ -1,4 +1,4 @@
-{-#LANGUAGE KindSignatures, GADTs, FlexibleContexts #-}
+{-#LANGUAGE KindSignatures, GADTs, FlexibleContexts, MultiParamTypeClasses, FunctionalDependencies #-}
 module Carnap.Calculi.Util where
 
 import Carnap.Core.Data.Types
@@ -11,14 +11,34 @@ import Carnap.Languages.ClassicalSequent.Syntax
 import Control.Monad.State
 import Text.Parsec (ParseError)
 
+--TODO eventually, Inference should be refactored into this together with
+--one or more ND-specific classes; also should probably be moved to a new
+--module
+class CoreInference r lex sem | r lex -> sem where
+
+        corePremisesOf :: r -> [ClassicalSequentOver lex (Sequent sem)]
+        corePremisesOf r = upperSequents (coreRuleOf r)
+
+        coreConclusionOf :: r -> ClassicalSequentOver lex (Sequent sem)
+        coreConclusionOf r = lowerSequent (coreRuleOf r)
+
+        coreRuleOf :: r -> SequentRule lex sem
+        coreRuleOf r = SequentRule (corePremisesOf r) (coreConclusionOf r)
+
+        --local restrictions, based only on given substitutions
+        coreRestriction :: r -> Maybe (Restriction lex)
+        coreRestriction _ = Nothing
+
+type Restriction lex = [Equation (ClassicalSequentOver lex)] -> Maybe String
+
 data ProofErrorMessage :: ((* -> *) -> * -> *) -> * where
         NoParse :: ParseError -> Int -> ProofErrorMessage lex
         NoUnify :: [[Equation (ClassicalSequentOver lex)]]  -> Int -> ProofErrorMessage lex
         GenericError :: String -> Int -> ProofErrorMessage lex
         NoResult :: Int -> ProofErrorMessage lex --meant for blanks
 
--- TODO These should be combined into a lens
-
+-- TODO These two should be combined into a lens
+lineNoOfError :: ProofErrorMessage lex -> Int
 lineNoOfError (NoParse _ n) = n
 lineNoOfError (NoUnify _ n) = n
 lineNoOfError (GenericError _ n) = n

--- a/Carnap/src/Carnap/Calculi/Util.hs
+++ b/Carnap/src/Carnap/Calculi/Util.hs
@@ -1,0 +1,56 @@
+{-#LANGUAGE KindSignatures, GADTs, FlexibleContexts #-}
+module Carnap.Calculi.Util where
+
+import Carnap.Core.Data.Types
+import Carnap.Core.Data.Classes
+import Carnap.Core.Unification.Unification
+import Carnap.Core.Unification.FirstOrder
+import Carnap.Core.Unification.Huet
+import Carnap.Core.Unification.ACUI
+import Carnap.Languages.ClassicalSequent.Syntax
+import Control.Monad.State
+import Text.Parsec (ParseError)
+
+data ProofErrorMessage :: ((* -> *) -> * -> *) -> * where
+        NoParse :: ParseError -> Int -> ProofErrorMessage lex
+        NoUnify :: [[Equation (ClassicalSequentOver lex)]]  -> Int -> ProofErrorMessage lex
+        GenericError :: String -> Int -> ProofErrorMessage lex
+        NoResult :: Int -> ProofErrorMessage lex --meant for blanks
+
+-- TODO These should be combined into a lens
+
+lineNoOfError (NoParse _ n) = n
+lineNoOfError (NoUnify _ n) = n
+lineNoOfError (GenericError _ n) = n
+lineNoOfError (NoResult n) = n
+
+renumber :: Int -> ProofErrorMessage lex -> ProofErrorMessage lex
+renumber m (NoParse x n) = NoParse x m
+renumber m (NoUnify x n) = NoUnify x m
+renumber m (GenericError s n) = GenericError s m
+renumber m (NoResult n) = NoResult m
+
+fosolve :: 
+    ( FirstOrder (ClassicalSequentOver lex)
+    , MonadVar (ClassicalSequentOver lex) (State Int)
+    ) =>  [Equation (ClassicalSequentOver lex)] -> Either (ProofErrorMessage lex) [Equation (ClassicalSequentOver lex)]
+fosolve eqs = case evalState (foUnifySys (const False) eqs) (0 :: Int) of 
+                [] -> Left $ NoUnify [eqs] 0
+                [s] -> Right s
+
+hosolve :: 
+    ( HigherOrder (ClassicalSequentOver lex)
+    , MonadVar (ClassicalSequentOver lex) (State Int)
+    ) => [Equation (ClassicalSequentOver lex)] -> Either (ProofErrorMessage lex) [[Equation (ClassicalSequentOver lex)]]
+hosolve eqs = case evalState (huetUnifySys (const False) eqs) (0 :: Int) of
+                    [] -> Left $ NoUnify [eqs] 0
+                    subs -> Right subs
+
+acuisolve :: 
+    ( ACUI (ClassicalSequentOver lex)
+    , MonadVar (ClassicalSequentOver lex) (State Int)
+    ) => [Equation (ClassicalSequentOver lex)] -> Either (ProofErrorMessage lex) [[Equation (ClassicalSequentOver lex)]]
+acuisolve eqs = 
+        case evalState (acuiUnifySys (const False) eqs) (0 :: Int) of
+          [] -> Left $ NoUnify [eqs] 0
+          subs -> Right subs

--- a/Carnap/src/Carnap/Core/Data/Util.hs
+++ b/Carnap/src/Carnap/Core/Data/Util.hs
@@ -1,7 +1,7 @@
 {-#LANGUAGE ImpredicativeTypes, FlexibleContexts, RankNTypes,TypeOperators, ScopedTypeVariables, GADTs, MultiParamTypeClasses #-}
 
 module Carnap.Core.Data.Util (scopeHeight, equalizeTypes, incArity, withArity, checkChildren, saferSubst,
-mapover, maphead, (:~:)(Refl), Buds(..), Blossoms(..), bloom, sbloom, grow, rebuild, castToProxy, castTo) where
+mapover, maphead, hasVar, (:~:)(Refl), Buds(..), Blossoms(..), bloom, sbloom, grow, rebuild, castToProxy, castTo) where
 
 --this module defines utility functions and typeclasses for manipulating
 --the data types defined in Core.Data
@@ -101,8 +101,13 @@ maphead f x@(Fx _) = f x
 this function will, given a suitably polymorphic argument `f`, apply `f` to the children of the linguistic expression `le`, but not the head.
 -}
 mapbody :: (forall a. Typeable a => FixLang l a -> FixLang l a) -> FixLang l b -> FixLang l b
-mapbody f le@(x :!$: y) = maphead f x :!$: f y
+mapbody f (x :!$: y) = maphead f x :!$: f y
 mapbody f x@(Fx _) = x
+
+hasVar :: (StaticVar (FixLang l), FirstOrder (FixLang l)) => FixLang l b -> Bool
+hasVar (x :!$: y) = hasVar x || hasVar y
+hasVar (LLam f) = hasVar $ f (static 0)
+hasVar x = isVar x
 
 {-|
 This function will assign a height to a given linguistic expression,

--- a/Carnap/src/Carnap/Languages/ClassicalSequent/Syntax.hs
+++ b/Carnap/src/Carnap/Languages/ClassicalSequent/Syntax.hs
@@ -181,7 +181,7 @@ class Typeable a => Concretes lex a where
             Just Refl -> f x
             Nothing -> pure x
 
-instance Concretes lex (Form Bool)
+instance Typeable a => Concretes lex a
 
 instance PrismBooleanConnLex lex b => PrismBooleanConnLex (ClassicalSequentLexOver lex) b
 instance PrismGenericContext lex b b => PrismGenericContext (ClassicalSequentLexOver lex) b b

--- a/Carnap/src/Carnap/Languages/ClassicalSequent/Syntax.hs
+++ b/Carnap/src/Carnap/Languages/ClassicalSequent/Syntax.hs
@@ -144,10 +144,10 @@ instance ( FirstOrderLex (t (ClassicalSequentOver t))
 
         acuiOp a Top = a
         acuiOp a Bot = a
+        acuiOp a SID = a
         acuiOp Top b = b
         acuiOp Bot b = b
         acuiOp SID b = b
-        acuiOp a SID = a
         acuiOp x@(_ :+: _) y   = x :+: y
         acuiOp x y@(_ :+: _)   = x :+: y
         acuiOp x@(_ :-: _) y   = x :-: y

--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Carnap.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Carnap.hs
@@ -94,8 +94,7 @@ instance Inference FOLogic PureLexiconFOL (Form Bool) where
 
 parseFOLogic :: RuntimeNaturalDeductionConfig PureLexiconFOL (Form Bool) -> Parsec String u [FOLogic]
 parseFOLogic rtc = try quantRule <|> liftProp
-    where liftProp = do r <- parsePropLogic (RuntimeNaturalDeductionConfig mempty mempty)
-                        return (map SL r)
+    where liftProp = map SL <$> parsePropLogic (RuntimeNaturalDeductionConfig mempty mempty)
           quantRule = do r <- choice (map (try . string) ["PR", "UI", "UD", "EG", "ED", "QN","LL","EL","Id","Sm","D-"])
                          case r of 
                             r | r == "PR" -> return [PR $ problemPremises rtc]

--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Gentzen.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Gentzen.hs
@@ -1,0 +1,74 @@
+{-#LANGUAGE FlexibleContexts, FlexibleInstances, UndecidableInstances, MultiParamTypeClasses #-}
+module Carnap.Languages.PureFirstOrder.Logic.Gentzen
+    ( parseGentzenFOLK, gentzenFOLKCalc, GentzenFOLK(..)) where
+
+import Text.Parsec
+import Data.Typeable
+import Carnap.Languages.ClassicalSequent.Syntax
+import Carnap.Core.Data.Types
+import Carnap.Core.Data.Classes
+import Carnap.Core.Data.Optics
+import Carnap.Languages.PureFirstOrder.Syntax
+import Carnap.Languages.PureFirstOrder.Parser
+import Carnap.Languages.PureFirstOrder.Logic.Rules
+import Carnap.Languages.PurePropositional.Logic.Gentzen
+import Carnap.Calculi.Tableau.Data
+import Carnap.Calculi.Util
+import Carnap.Languages.Util.LanguageClasses
+
+data GentzenFOLK = LK GentzenPropLK 
+                | AllL   | AllR
+                | ExistL | ExistR
+
+instance Show GentzenFOLK where
+    show (LK x) = show x
+    show AllL   = "L∀"
+    show AllR   = "R∀"
+    show ExistL = "L∃"
+    show ExistR = "R∃"
+
+parseGentzenFOLK :: Parsec String u GentzenFOLK
+parseGentzenFOLK = try folParse <|> liftProp
+        where liftProp = LK <$> parseGentzenPropLK
+              folParse = do r <- choice (map (try . string) [ "LA", "L∀", "RA","R∀", "LE","L∃", "RE", "R∃" ])
+                            return $ case r of
+                               r | r `elem` ["LA","L∀"] -> AllL
+                                 | r `elem` ["RA","R∀"] -> AllR
+                                 | r `elem` ["LE","L∃"] -> ExistL
+                                 | r `elem` ["RE","R∃"] -> ExistR
+
+instance ( BooleanLanguage (ClassicalSequentOver lex (Form Bool))
+         , BooleanConstLanguage (ClassicalSequentOver lex (Form Bool))
+         , IndexedSchemePropLanguage (ClassicalSequentOver lex (Form Bool))
+         , IndexedSchemeConstantLanguage (ClassicalSequentOver lex (Term Int))
+         , QuantLanguage (ClassicalSequentOver lex (Form Bool)) (ClassicalSequentOver lex (Term Int)) 
+         , PolyadicSchematicPredicateLanguage (ClassicalSequentOver lex) (Term Int) (Form Bool)
+         , PrismPolyadicSchematicFunction lex Int Int 
+         , PrismIndexedConstant lex Int
+         , PrismStandardVar lex Int
+         , CopulaSchema (ClassicalSequentOver lex)
+         , Schematizable (lex (ClassicalSequentOver lex))
+         , FirstOrderLex (lex (ClassicalSequentOver lex))
+         , PrismSubstitutionalVariable lex
+         ) => CoreInference GentzenFOLK lex (Form Bool) where
+         corePremisesOf (LK x) = corePremisesOf x
+         corePremisesOf AllL = [SA (phi 1 (taun 1)) :+: GammaV 1 :|-: DeltaV 1]
+         corePremisesOf AllR = [ GammaV 1 :|-: DeltaV 1 :-: SS (phi 1 (taun 1))]
+         corePremisesOf ExistL = [SA (phi 1 (taun 1)) :+: GammaV 1 :|-: DeltaV 1]
+         corePremisesOf ExistR = [ GammaV 1 :|-: DeltaV 1 :-: SS (phi 1 (taun 1))]
+
+         coreConclusionOf (LK x) = coreConclusionOf x
+         coreConclusionOf AllL = SA (lall "v" (phi 1)) :+: GammaV 1 :|-: DeltaV 1
+         coreConclusionOf AllR =  GammaV 1 :|-: SS (lall "v" (phi 1)) :-: DeltaV 1
+         coreConclusionOf ExistL = SA (lsome "v" (phi 1)) :+: GammaV 1 :|-: DeltaV 1
+         coreConclusionOf ExistR =  GammaV 1 :|-: SS (lsome "v" (phi 1)) :-: DeltaV 1
+
+         coreRestriction AllR = Just $ eigenConstraint (taun 1) (SS (lall "v" (phi' 1)) :-: fodelta 1) (fogamma 1)
+         coreRestriction ExistL = Just $ eigenConstraint (taun 1) (fodelta 1) (SA (lsome "v" (phi' 1)) :+: fogamma 1)
+         coreRestriction _ = Nothing
+
+gentzenFOLKCalc :: TableauCalc PureLexiconFOL (Form Bool) GentzenFOLK
+gentzenFOLKCalc = TableauCalc 
+    { tbParseForm = langParser
+    , tbParseRule = parseGentzenFOLK
+    }

--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Gentzen.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Gentzen.hs
@@ -12,6 +12,7 @@ import Carnap.Languages.PureFirstOrder.Syntax
 import Carnap.Languages.PureFirstOrder.Parser
 import Carnap.Languages.PureFirstOrder.Logic.Rules
 import Carnap.Languages.PurePropositional.Logic.Gentzen
+import Carnap.Languages.Util.GenericConstructors
 import Carnap.Calculi.Tableau.Data
 import Carnap.Calculi.Util
 import Carnap.Languages.Util.LanguageClasses
@@ -43,13 +44,13 @@ instance ( BooleanLanguage (ClassicalSequentOver lex (Form Bool))
          , IndexedSchemeConstantLanguage (ClassicalSequentOver lex (Term Int))
          , QuantLanguage (ClassicalSequentOver lex (Form Bool)) (ClassicalSequentOver lex (Term Int)) 
          , PolyadicSchematicPredicateLanguage (ClassicalSequentOver lex) (Term Int) (Form Bool)
-         , PrismPolyadicSchematicFunction lex Int Int 
-         , PrismIndexedConstant lex Int
-         , PrismStandardVar lex Int
+         , PrismPolyadicSchematicFunction (ClassicalSequentLexOver lex) Int Int 
+         , PrismIndexedConstant (ClassicalSequentLexOver lex) Int
+         , PrismStandardVar (ClassicalSequentLexOver lex) Int
          , CopulaSchema (ClassicalSequentOver lex)
          , Schematizable (lex (ClassicalSequentOver lex))
          , FirstOrderLex (lex (ClassicalSequentOver lex))
-         , PrismSubstitutionalVariable lex
+         , PrismSubstitutionalVariable (ClassicalSequentLexOver lex)
          ) => CoreInference GentzenFOLK lex (Form Bool) where
          corePremisesOf (LK x) = corePremisesOf x
          corePremisesOf AllL = [SA (phi 1 (taun 1)) :+: GammaV 1 :|-: DeltaV 1]

--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Gentzen.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Gentzen.hs
@@ -1,6 +1,8 @@
 {-#LANGUAGE RankNTypes, ScopedTypeVariables, FlexibleContexts, FlexibleInstances, UndecidableInstances, MultiParamTypeClasses #-}
 module Carnap.Languages.PureFirstOrder.Logic.Gentzen
-    ( parseGentzenFOLK, gentzenFOLKCalc, GentzenFOLK(..)) where
+( parseGentzenFOLK, gentzenFOLKCalc, GentzenFOLK(..)
+, parseGentzenFOLJ, gentzenFOLJCalc, GentzenFOLJ(..)
+) where
 
 import Text.Parsec
 import Data.List
@@ -111,4 +113,10 @@ gentzenFOLKCalc :: TableauCalc PureLexiconFOL (Form Bool) GentzenFOLK
 gentzenFOLKCalc = TableauCalc 
     { tbParseForm = langParser
     , tbParseRule = parseGentzenFOLK
+    }
+
+gentzenFOLJCalc :: TableauCalc PureLexiconFOL (Form Bool) GentzenFOLJ
+gentzenFOLJCalc = TableauCalc 
+    { tbParseForm = langParser
+    , tbParseRule = parseGentzenFOLJ
     }

--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Goldfarb.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Goldfarb.hs
@@ -65,6 +65,9 @@ instance Inference GoldfarbND PureLexiconFOL (Form Bool) where
     globalRestriction (Left ded) n D = Just (P.dischargeConstraint n ded (view lhs $ conclusionOf D))
     globalRestriction _ _ _ = Nothing
 
+    indirectInference D = Just $ TypedProof (ProofType 1 1)
+    indirectInference _ = Nothing
+
     isAssumption P = True
     isAssumption _ = False
 
@@ -130,6 +133,10 @@ instance Inference GoldfarbNDPlus PureLexiconFOL (Form Bool) where
               theSuc = SS (phin 1 :: FOLSequentCalc (Form Bool))
 
     globalRestriction _ _ _ = Nothing
+
+    indirectInference (ND x) = indirectInference x
+    indirectInference EIE = Just $ TypedProof (ProofType 1 1)
+    indirectInference _ = Nothing
 
     isAssumption (ND s)  = isAssumption s
     isAssumption (EII _) = True

--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Rules.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Rules.hs
@@ -20,7 +20,7 @@ import Carnap.Languages.ClassicalSequent.Syntax
 import Carnap.Languages.ClassicalSequent.Parser
 import Carnap.Languages.Util.LanguageClasses
 import Carnap.Languages.Util.GenericConstructors
-import Carnap.Calculi.NaturalDeduction.Syntax (DeductionLine(..),depth,assertion,discharged,justificationOf,inScope,Restriction)
+import Carnap.Calculi.NaturalDeduction.Syntax (DeductionLine(..),depth,assertion,discharged,justificationOf,inScope)
 
 --------------------------------------------------------
 --1. FirstOrder Sequent Calculus

--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Rules.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Rules.hs
@@ -7,7 +7,7 @@ import Data.Maybe (catMaybes)
 import Control.Lens (toListOf,preview, Prism')
 import Text.Parsec
 import Carnap.Core.Data.Util 
-import Carnap.Core.Unification.Unification (applySub,occurs,FirstOrder)
+import Carnap.Core.Unification.Unification (applySub,occurs,FirstOrder, Equation)
 import Carnap.Core.Data.Classes
 import Carnap.Core.Data.Types
 import Carnap.Core.Data.Optics
@@ -72,6 +72,19 @@ theta :: SchematicPolyadicFunctionLanguage (FixLang lex) (Term Int) (Term Int)
     => (FixLang lex) (Term Int) -> (FixLang lex) (Term Int)
 theta x = spfn 1 AOne :!$: x
 
+eigenConstraint :: 
+    ( PrismStandardVar (ClassicalSequentLexOver lex) Int
+    , PrismIndexedConstant (ClassicalSequentLexOver lex) Int
+    , PrismPolyadicSchematicFunction (ClassicalSequentLexOver lex) Int Int
+    , Schematizable (lex (ClassicalSequentOver lex))
+    , FirstOrderLex (lex (ClassicalSequentOver lex))
+    , CopulaSchema (ClassicalSequentOver lex)
+    , PrismSubstitutionalVariable (ClassicalSequentLexOver lex)
+    ) => ClassicalSequentOver lex (Term Int) 
+         -> ClassicalSequentOver lex (Succedent (Form Bool)) 
+         -> ClassicalSequentOver lex (Antecedent (Form Bool)) 
+         -> [Equation (ClassicalSequentOver lex)]
+         -> Maybe String
 eigenConstraint c suc ant sub
     | (applySub sub c) `occurs` (applySub sub ant) = Just $ "The term " ++ show (applySub sub c) ++ " appears not to be fresh, given that this line relies on " ++ show (applySub sub ant)
     | (applySub sub c) `occurs` (applySub sub suc) = Just $ "The term " ++ show (applySub sub c) ++ " appears not to be fresh in the other premise " ++ show (applySub sub suc)
@@ -80,9 +93,8 @@ eigenConstraint c suc ant sub
                             | not . null $ preview _constIdx (applySub sub c) -> Nothing
                             | not . null $ preview _varLabel (applySub sub c) -> Nothing
                           _ -> Just $ "The term " ++ show (applySub sub c) ++ " is not a constant or variable"
-    where _sfuncIdx' :: ( PrismPolyadicSchematicFunction lex Int Int 
-                        , PrismLink (lex (ClassicalSequentOver lex)) (Function (SchematicIntFunc Int Int) (ClassicalSequentOver lex)) -- XXX: only for compatibility with older GHCs 
-                        ) => Prism' (ClassicalSequentOver lex (Term Int)) (Int, Arity (Term Int) (Term Int) (Term Int))
+    where _sfuncIdx' :: PrismPolyadicSchematicFunction (ClassicalSequentLexOver lex) Int Int 
+                     => Prism' (ClassicalSequentOver lex (Term Int)) (Int, Arity (Term Int) (Term Int) (Term Int))
           _sfuncIdx' = _sfuncIdx
 
 tautologicalConstraint prems conc sub = case prems' of

--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Rules.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Logic/Rules.hs
@@ -80,9 +80,9 @@ eigenConstraint c suc ant sub
                             | not . null $ preview _constIdx (applySub sub c) -> Nothing
                             | not . null $ preview _varLabel (applySub sub c) -> Nothing
                           _ -> Just $ "The term " ++ show (applySub sub c) ++ " is not a constant or variable"
-    where _sfuncIdx' :: ( PrismPolyadicSchematicFunction (PureFirstOrderLexWith a) Int Int 
-                        , PrismLink (a (OpenFOLSequentCalc a)) (Function (SchematicIntFunc Int Int) (OpenFOLSequentCalc a)) -- XXX: only for compatibility with older GHCs 
-                        ) => Prism' (OpenFOLSequentCalc a (Term Int)) (Int, Arity (Term Int) (Term Int) (Term Int))
+    where _sfuncIdx' :: ( PrismPolyadicSchematicFunction lex Int Int 
+                        , PrismLink (lex (ClassicalSequentOver lex)) (Function (SchematicIntFunc Int Int) (ClassicalSequentOver lex)) -- XXX: only for compatibility with older GHCs 
+                        ) => Prism' (ClassicalSequentOver lex (Term Int)) (Int, Arity (Term Int) (Term Int) (Term Int))
           _sfuncIdx' = _sfuncIdx
 
 tautologicalConstraint prems conc sub = case prems' of

--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Syntax.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Syntax.hs
@@ -238,6 +238,9 @@ maxVar t@(Fx _) = case ttype t >>= preview _varLabel >>= readMaybe of
 fogamma :: Int -> ClassicalSequentOver lex (Antecedent (Form Bool))
 fogamma n = GammaV n
 
+fodelta:: Int -> ClassicalSequentOver lex (Succedent (Form Bool))
+fodelta n = DeltaV n
+
 termsOf :: (BoundVars lex, Typeable sem) => FirstOrder (FixLang lex) => Traversal' (FixLang lex sem) (FixLang lex (Term Int))
 termsOf = genChildren
 

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/Gentzen.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/Gentzen.hs
@@ -1,6 +1,7 @@
 {-#LANGUAGE RankNTypes, ScopedTypeVariables, FlexibleContexts, FlexibleInstances, UndecidableInstances, MultiParamTypeClasses #-}
 module Carnap.Languages.PurePropositional.Logic.Gentzen
-    ( parseGentzenPropLK, gentzenPropLKCalc, GentzenPropLK(..)) where
+    ( parseGentzenPropLK, gentzenPropLKCalc, GentzenPropLK()
+    , parseGentzenPropLJ, gentzenPropLJCalc, GentzenPropLJ()) where
 
 import Text.Parsec
 import Data.List
@@ -134,4 +135,10 @@ gentzenPropLKCalc :: TableauCalc PurePropLexicon (Form Bool) GentzenPropLK
 gentzenPropLKCalc = TableauCalc 
     { tbParseForm = langParser
     , tbParseRule = parseGentzenPropLK
+    }
+
+gentzenPropLJCalc :: TableauCalc PurePropLexicon (Form Bool) GentzenPropLJ
+gentzenPropLJCalc = TableauCalc 
+    { tbParseForm = langParser
+    , tbParseRule = parseGentzenPropLJ
     }

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/Gentzen.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/Gentzen.hs
@@ -1,4 +1,4 @@
-{-#LANGUAGE FlexibleContexts, FlexibleInstances, MultiParamTypeClasses #-}
+{-#LANGUAGE FlexibleContexts, FlexibleInstances, UndecidableInstances, MultiParamTypeClasses #-}
 module Carnap.Languages.PurePropositional.Logic.Gentzen
     ( parseGentzenPropLK, gentzenPropLKCalc, GentzenPropLK(..)) where
 
@@ -60,42 +60,45 @@ parseGentzenPropLK =  do r <- choice (map (try . string) [ "Ax", "Rep", "Cut"
                               | r `elem` ["L¬","L~","L-"] -> NegL
                               | r `elem` ["R¬","R~","R-"] -> NegR
 
-instance CoreInference GentzenPropLK PurePropLexicon (Form Bool) where
-        corePremisesOf AndL1 = [SA (phin 1) :+: GammaV 1 :|-: DeltaV 1]
-        corePremisesOf AndL2 = [SA (phin 2) :+: GammaV 1 :|-: DeltaV 1]
-        corePremisesOf AndR = [ GammaV 1 :|-: SS (phin 1) :-: DeltaV 1
-                              , GammaV 2 :|-: SS (phin 2) :-: DeltaV 2
-                              ]
-        corePremisesOf OrR1 = [ GammaV 1 :|-: DeltaV 1 :-: SS(phin 1)]
-        corePremisesOf OrR2 = [ GammaV 1 :|-: DeltaV 1 :-: SS(phin 2)]
-        corePremisesOf OrL  = [ GammaV 1 :+: SA (phin 1) :|-: DeltaV 1
-                              , GammaV 2 :+: SA (phin 1) :|-: DeltaV 2
-                              ] 
-        corePremisesOf CondL = [ GammaV 1 :|-: SS (phin 1) :-: DeltaV 1
-                               , GammaV 2 :+: SA (phin 2) :|-: DeltaV 2
+instance ( BooleanLanguage (ClassicalSequentOver lex (Form Bool))
+         , BooleanConstLanguage (ClassicalSequentOver lex (Form Bool))
+         , IndexedSchemePropLanguage (ClassicalSequentOver lex (Form Bool))
+         ) => CoreInference GentzenPropLK lex (Form Bool) where
+         corePremisesOf AndL1 = [SA (phin 1) :+: GammaV 1 :|-: DeltaV 1]
+         corePremisesOf AndL2 = [SA (phin 2) :+: GammaV 1 :|-: DeltaV 1]
+         corePremisesOf AndR = [ GammaV 1 :|-: SS (phin 1) :-: DeltaV 1
+                               , GammaV 2 :|-: SS (phin 2) :-: DeltaV 2
                                ]
-        corePremisesOf CondR = [ GammaV 1 :+: SA (phin 1) :|-: SS (phin 2) :-: DeltaV 2 ]
-        corePremisesOf NegL = [ GammaV 1 :|-: SS (phin 1) :-: DeltaV 1 ]
-        corePremisesOf NegR = [ SA (phin 1) :+: GammaV 1 :|-:  DeltaV 1 ]
-        corePremisesOf Rep =  [GammaV 1 :|-: DeltaV 1 ]
-        corePremisesOf Cut =  [ SA (phin 1) :+: GammaV 1 :|-: DeltaV 1 
-                              , GammaV 2 :|-: DeltaV 2 :-: SS (phin 1)
-                              ]
-        corePremisesOf Ax = [] 
+         corePremisesOf OrR1 = [ GammaV 1 :|-: DeltaV 1 :-: SS(phin 1)]
+         corePremisesOf OrR2 = [ GammaV 1 :|-: DeltaV 1 :-: SS(phin 2)]
+         corePremisesOf OrL  = [ GammaV 1 :+: SA (phin 1) :|-: DeltaV 1
+                               , GammaV 2 :+: SA (phin 1) :|-: DeltaV 2
+                               ] 
+         corePremisesOf CondL = [ GammaV 1 :|-: SS (phin 1) :-: DeltaV 1
+                                , GammaV 2 :+: SA (phin 2) :|-: DeltaV 2
+                                ]
+         corePremisesOf CondR = [ GammaV 1 :+: SA (phin 1) :|-: SS (phin 2) :-: DeltaV 2 ]
+         corePremisesOf NegL = [ GammaV 1 :|-: SS (phin 1) :-: DeltaV 1 ]
+         corePremisesOf NegR = [ SA (phin 1) :+: GammaV 1 :|-:  DeltaV 1 ]
+         corePremisesOf Rep =  [GammaV 1 :|-: DeltaV 1 ]
+         corePremisesOf Cut =  [ SA (phin 1) :+: GammaV 1 :|-: DeltaV 1 
+                               , GammaV 2 :|-: DeltaV 2 :-: SS (phin 1)
+                               ]
+         corePremisesOf Ax = [] 
 
-        coreConclusionOf AndL1 = SA (phin 1 ./\. phin 2) :+: GammaV 1 :|-: DeltaV 1
-        coreConclusionOf AndL2 = SA (phin 1 ./\. phin 2) :+: GammaV 1 :|-: DeltaV 1
-        coreConclusionOf AndR = GammaV 1 :+: GammaV 2 :|-: SS (phin 1 ./\. phin 2) :-: DeltaV 1 :-: DeltaV 2
-        coreConclusionOf OrR1 =  GammaV 1 :|-: SS (phin 1 .\/. phin 2) :-: DeltaV 1
-        coreConclusionOf OrR2 = GammaV 1 :|-: SS (phin 1 .\/. phin 2) :-: DeltaV 1
-        coreConclusionOf OrL = SA (phin 1 .\/. phin 2) :+: GammaV 1 :+: GammaV 2 :|-:  DeltaV 1 :-: DeltaV 2
-        coreConclusionOf CondL = SA (phin 1 .=>. phin 2) :+: GammaV 1 :+: GammaV 2 :|-:  DeltaV 1 :-: DeltaV 2
-        coreConclusionOf CondR =  GammaV 1 :+: GammaV 2 :|-:  SS (phin 1 .=>. phin 2) :-: DeltaV 1 :-: DeltaV 2
-        coreConclusionOf NegL = SA (lneg $ phin 1) :+: GammaV 1 :|-: DeltaV 1
-        coreConclusionOf NegR =  GammaV 1 :|-: SS (lneg $ phin 1) :-: DeltaV 1
-        coreConclusionOf Rep =  GammaV 1 :|-: DeltaV 1 
-        coreConclusionOf Cut =  GammaV 1 :+: GammaV 2 :|-: DeltaV 1 :-: DeltaV 2
-        coreConclusionOf Ax =  GammaV 1 :+: SA (phin 1) :|-: SS (phin 1) :-: DeltaV 1 
+         coreConclusionOf AndL1 = SA (phin 1 ./\. phin 2) :+: GammaV 1 :|-: DeltaV 1
+         coreConclusionOf AndL2 = SA (phin 1 ./\. phin 2) :+: GammaV 1 :|-: DeltaV 1
+         coreConclusionOf AndR = GammaV 1 :+: GammaV 2 :|-: SS (phin 1 ./\. phin 2) :-: DeltaV 1 :-: DeltaV 2
+         coreConclusionOf OrR1 =  GammaV 1 :|-: SS (phin 1 .\/. phin 2) :-: DeltaV 1
+         coreConclusionOf OrR2 = GammaV 1 :|-: SS (phin 1 .\/. phin 2) :-: DeltaV 1
+         coreConclusionOf OrL = SA (phin 1 .\/. phin 2) :+: GammaV 1 :+: GammaV 2 :|-:  DeltaV 1 :-: DeltaV 2
+         coreConclusionOf CondL = SA (phin 1 .=>. phin 2) :+: GammaV 1 :+: GammaV 2 :|-:  DeltaV 1 :-: DeltaV 2
+         coreConclusionOf CondR =  GammaV 1 :+: GammaV 2 :|-:  SS (phin 1 .=>. phin 2) :-: DeltaV 1 :-: DeltaV 2
+         coreConclusionOf NegL = SA (lneg $ phin 1) :+: GammaV 1 :|-: DeltaV 1
+         coreConclusionOf NegR =  GammaV 1 :|-: SS (lneg $ phin 1) :-: DeltaV 1
+         coreConclusionOf Rep =  GammaV 1 :|-: DeltaV 1 
+         coreConclusionOf Cut =  GammaV 1 :+: GammaV 2 :|-: DeltaV 1 :-: DeltaV 2
+         coreConclusionOf Ax =  GammaV 1 :+: SA (phin 1) :|-: SS (phin 1) :-: DeltaV 1 
 
 gentzenPropLKCalc :: TableauCalc PurePropLexicon (Form Bool) GentzenPropLK
 gentzenPropLKCalc = TableauCalc 

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/Gentzen.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/Gentzen.hs
@@ -1,0 +1,92 @@
+{-#LANGUAGE FlexibleContexts, FlexibleInstances, MultiParamTypeClasses #-}
+module Carnap.Languages.PurePropositional.Logic.Gentzen
+    ( parseGentzenPropLK, gentzenPropLKCalc, GentzenPropLK(..)) where
+
+import Text.Parsec
+import Carnap.Languages.ClassicalSequent.Syntax
+import Carnap.Core.Data.Types (Form)
+import Carnap.Languages.PurePropositional.Syntax
+import Carnap.Languages.PurePropositional.Parser
+import Carnap.Calculi.Tableau.Data
+import Carnap.Calculi.Util
+import Carnap.Languages.Util.LanguageClasses
+
+data GentzenPropLK = Ax | AndL1 | AndL2 | AndR
+                        | OrR1  | OrR2  | OrL
+                        | CondR | CondL
+                        | NegR  | NegL
+
+instance Show GentzenPropLK where
+    show Ax     = "Ax"
+    show AndL1  = "L&1"
+    show AndL2  = "L&2"
+    show AndR   = "R&"
+    show OrR1   = "R∨1" 
+    show OrR2   = "R∨2"
+    show OrL    = "L∨"
+    show CondR  = "R→"
+    show CondL  = "L→"
+    show NegR   = "R¬" 
+    show NegL   = "L¬"
+
+parseGentzenPropLK :: Parsec String u GentzenPropLK
+parseGentzenPropLK =  do r <- choice (map (try . string) [ "Ax", "R&","R∧","R/\\"
+                                                         ,"L&1","L∧1","L/\\1"
+                                                         ,"L&2","L∧2","L/\\2"
+                                                         , "L∨","Lv","L\\/"
+                                                         ,"R∨1","Rv1","R\\/1"
+                                                         ,"R∨2","Rv2","R\\/2"
+                                                         , "L→","LC","L->"
+                                                         , "R→","RC","R->"
+                                                         , "L¬","L~","L-"
+                                                         , "R¬","R~","R-"
+                                                         ])
+                         return $ case r of
+                            r | r == "Ax" -> Ax
+                              | r `elem` ["R&","R∧","R/\\"] -> AndR
+                              | r `elem` ["L&1","L∧1","L/\\1"] -> AndL1
+                              | r `elem` ["L&2","L∧2","L/\\2"] -> AndL2
+                              | r `elem` ["L∨","Lv","L\\/"] -> OrL
+                              | r `elem` ["R∨1","Rv1","R\\/1"] -> OrR1
+                              | r `elem` ["R∨2","Rv2","R\\/2"] -> OrR2
+                              | r `elem` ["L→","LC","L->"] -> CondL
+                              | r `elem` ["R→","RC","R->"] -> CondR
+                              | r `elem` ["L¬","L~","L-"] -> NegL
+                              | r `elem` ["R¬","R~","R-"] -> NegR
+
+instance CoreInference GentzenPropLK PurePropLexicon (Form Bool) where
+        corePremisesOf AndL1 = [SA (phin 1) :+: GammaV 1 :|-: DeltaV 1]
+        corePremisesOf AndL2 = [SA (phin 2) :+: GammaV 1 :|-: DeltaV 1]
+        corePremisesOf AndR = [ GammaV 1 :|-: SS (phin 1) :-: DeltaV 1
+                              , GammaV 2 :|-: SS (phin 2) :-: DeltaV 2
+                              ]
+        corePremisesOf OrR1 = [ GammaV 1 :|-: DeltaV 1 :-: SS(phin 1)]
+        corePremisesOf OrR1 = [ GammaV 1 :|-: DeltaV 1 :-: SS(phin 2)]
+        corePremisesOf OrL  = [ GammaV 1 :+: SA (phin 1) :|-: DeltaV 1
+                              , GammaV 2 :+: SA (phin 1) :|-: DeltaV 2
+                              ] 
+        corePremisesOf CondL = [ GammaV 1 :|-: SS (phin 1) :-: DeltaV 1
+                               , GammaV 2 :+: SA (phin 2) :|-: DeltaV 2
+                               ]
+        corePremisesOf CondR = [ GammaV 1 :+: SA (phin 1) :|-: SS (phin 2) :-: DeltaV 2 ]
+        corePremisesOf NegL = [ GammaV 1 :|-: SS (phin 1) :-: DeltaV 1 ]
+        corePremisesOf NegR = [ SA (phin 1) :+: GammaV 1 :|-:  DeltaV 1 ]
+        corePremisesOf Ax = [] 
+
+        coreConclusionOf AndL1 = SA (phin 1 ./\. phin 2) :+: GammaV 1 :|-: DeltaV 1
+        coreConclusionOf AndL2 = SA (phin 1 ./\. phin 2) :+: GammaV 1 :|-: DeltaV 1
+        coreConclusionOf AndR = GammaV 1 :+: GammaV 2 :|-: SS (phin 1 ./\. phin 2) :-: DeltaV 1 :-: DeltaV 2
+        coreConclusionOf OrR1 =  GammaV 1 :|-: SS (phin 1 .\/. phin 2) :-: DeltaV 1
+        coreConclusionOf OrR2 = GammaV 1 :|-: SS (phin 1 .\/. phin 2) :-: DeltaV 1
+        coreConclusionOf OrL = SA (phin 1 .\/. phin 2) :+: GammaV 1 :+: GammaV 2 :|-:  DeltaV 1 :-: DeltaV 2
+        coreConclusionOf CondL = SA (phin 1 .=>. phin 2) :+: GammaV 1 :+: GammaV 2 :|-:  DeltaV 1 :-: DeltaV 2
+        coreConclusionOf CondR =  GammaV 1 :+: GammaV 2 :|-:  SS (phin 1 .=>. phin 2) :-: DeltaV 1 :-: DeltaV 2
+        coreConclusionOf NegL = SA (lneg $ phin 1) :+: GammaV 1 :|-: DeltaV 1
+        coreConclusionOf NegR =  GammaV 1 :|-: SS (lneg $ phin 1) :-: DeltaV 1
+        coreConclusionOf Ax =  GammaV 1 :+: SA (phin 1) :|-: SS (phin 1) :-: DeltaV 1 
+
+gentzenPropLKCalc :: TableauCalc PurePropLexicon (Form Bool) GentzenPropLK
+gentzenPropLKCalc = TableauCalc 
+    { tbParseForm = langParser
+    , tbParseRule = parseGentzenPropLK
+    }

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/IchikawaJenkins.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/IchikawaJenkins.hs
@@ -9,6 +9,7 @@ import Carnap.Languages.PurePropositional.Syntax
 import Carnap.Languages.PurePropositional.Parser
 import Carnap.Languages.PurePropositional.Logic.Magnus
 import Carnap.Calculi.Util
+import Carnap.Calculi.Tableau.Data
 import Carnap.Calculi.NaturalDeduction.Syntax
 import Carnap.Calculi.NaturalDeduction.Parser
 import Carnap.Calculi.NaturalDeduction.Checker
@@ -199,3 +200,8 @@ instance CoreInference IchikawaJenkinsSLTableaux PurePropLexicon (Form Bool) whe
         coreConclusionOf Bicond = SA (phin 1 .<=>. phin 2) :+: GammaV 1 :+: GammaV 2 :|-: Bot
         coreConclusionOf NBicond = SA (lneg $ phin 1 .<=>. phin 2) :+: GammaV 1 :+: GammaV 2 :|-: Bot
         coreConclusionOf DoubleNeg = SA (lneg $ lneg $ phin 1)  :+: GammaV 1 :|-: Bot
+
+ichkawaJenkinsSLTableauCalc = TableauCalc 
+    { tbParseForm = purePropFormulaParser magnusOpts
+    , tbParseRule = parseIchikawaJenkinsSLTableaux
+    }

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/IchikawaJenkins.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/IchikawaJenkins.hs
@@ -21,8 +21,7 @@ import Carnap.Languages.Util.LanguageClasses
 --  Natural Deduction  --
 -------------------------
 
-newtype IchikawaJenkinsSL = IJ MagnusSLPlus
-    deriving Eq
+newtype IchikawaJenkinsSL = IJ MagnusSLPlus deriving Eq
 
 instance Show IchikawaJenkinsSL where
         show (IJ (MSL CondIntro1)) = "⊃I"
@@ -169,7 +168,6 @@ parseIchikawaJenkinsSLTableaux = do r <- choice (map (try . string) ["&","¬&","
                                          | r `elem` ["≡","<->","<>","B"] -> Bicond
                                          | r `elem` [ "¬≡","~≡","-≡", "¬<->","~<->","-<->", "¬<>","~<>","-<>", "¬B","~B","-B"] -> NBicond
                                          | r `elem` [ "¬¬","~~","--"] -> DoubleNeg
-
 
 instance CoreInference IchikawaJenkinsSLTableaux PurePropLexicon (Form Bool) where
         corePremisesOf Conj = [SA (phin 1) :+: SA (phin 2) :+: GammaV 1 :|-: Bot]

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/IchikawaJenkins.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/IchikawaJenkins.hs
@@ -8,12 +8,18 @@ import Carnap.Core.Data.Types (Form)
 import Carnap.Languages.PurePropositional.Syntax
 import Carnap.Languages.PurePropositional.Parser
 import Carnap.Languages.PurePropositional.Logic.Magnus
+import Carnap.Calculi.Util
 import Carnap.Calculi.NaturalDeduction.Syntax
 import Carnap.Calculi.NaturalDeduction.Parser
 import Carnap.Calculi.NaturalDeduction.Checker
 import Carnap.Languages.ClassicalSequent.Syntax
 import Carnap.Languages.ClassicalSequent.Parser
 import Carnap.Languages.PurePropositional.Logic.Rules
+import Carnap.Languages.Util.LanguageClasses
+
+-------------------------
+--  Natural Deduction  --
+-------------------------
 
 newtype IchikawaJenkinsSL = IJ MagnusSLPlus
     deriving Eq
@@ -46,16 +52,13 @@ instance Inference IchikawaJenkinsSL PurePropLexicon (Form Bool) where
         indirectInference _ = Nothing
 
         isAssumption (IJ x) = isAssumption x
-        isAssumption _ = False
 
         isPremise (IJ x) = isPremise x
-        isPremise _ = False
 
         restriction (IJ x) = restriction x
-        restriction _ = Nothing
 
 parseIchikawaJenkinsSL :: RuntimeNaturalDeductionConfig PurePropLexicon (Form Bool) -> Parsec String u [IchikawaJenkinsSL]
-parseIchikawaJenkinsSL rtc = do r <- choice (map (try . string) ["AS","PR","&I","/\\I", "∧I","&E","/\\E","∧E","CI",">I","->I","⊃I","→E","CE",">E", "->E", "⊃E"
+parseIchikawaJenkinsSL rtc = do r <- choice (map (try . string) ["AS","PR","&I","/\\I", "∧I","&E","/\\E","∧E","CI",">I","->I","⊃I","CE",">E", "->E", "⊃E"
                                                          ,"~I","-I", "¬I","~E","-E","¬E" ,"vI","\\/I","∨I", "vE","\\/E", "∨E","BI","<>I","<->I", "≡I" 
                                                          , "BE", "<>E","<->E", "≡E", "R", "HYP","DIL","MT", "Comm", "DN", "MC", "≡ex", "<>ex", "<->ex", "DeM"])
                                                          <|> ((++) <$> string "A/" <*> many anyChar)
@@ -121,3 +124,80 @@ ichikawaJenkinsSLCalc = mkNDCalc
     , ndParseForm = purePropFormulaParser magnusOpts
     , ndNotation = ichikawaJenkinsNotation
     }
+
+-------------------------
+--  Semantic Tableaux  --
+-------------------------
+
+data IchikawaJenkinsSLTableaux = Conj | NConj | Disj | NDisj | Cond | NCond | Bicond | NBicond | DoubleNeg
+    deriving Eq
+
+instance Show IchikawaJenkinsSLTableaux where
+    show Conj = "&"
+    show NConj = "¬&"
+    show Disj  = "∨"
+    show NDisj = "¬∨"
+    show Cond = "⊃" 
+    show NCond = "¬⊃"
+    show Bicond = "≡"
+    show NBicond = "¬≡"
+    show DoubleNeg = "¬¬"
+
+parseIchikawaJenkinsSLTableaux :: Parsec String u IchikawaJenkinsSLTableaux
+parseIchikawaJenkinsSLTableaux = do r <- choice (map (try . string) ["&","¬&","~&","-&"
+                                                                ,"∨","¬∨","~∨","-∨"
+                                                                , "v", "¬v","~v","-v"
+                                                                , "\\/", "¬\\/","~\\/","-\\/"
+                                                                , "⊃", "¬⊃","~⊃","-⊃"
+                                                                , "->", "¬->","~->","-->"
+                                                                , "->", "¬->","~->","-->"
+                                                                , ">", "¬>","~>","->"
+                                                                , "C", "¬C","~C","-C"
+                                                                , "≡", "¬≡","~≡","-≡"
+                                                                , "<->", "¬<->","~<->","-<->"
+                                                                , "<>", "¬<>","~<>","-<>"
+                                                                , "B", "¬B","~B","-B"
+                                                                , "¬¬","~~","--"
+                                                                ])
+                                    return $ case r of
+                                       r | r == "&" -> Conj
+                                         | r `elem` ["¬&","~&","-&"] -> NConj
+                                         | r `elem` ["∨","v","\\/"] -> Disj
+                                         | r `elem` [ "¬∨","~∨","-∨", "¬\\/","~\\/","-\\/", "¬v","~v","-v"] -> NDisj
+                                         | r `elem` ["⊃","->",">","C"] -> Cond
+                                         | r `elem` [ "¬⊃","~⊃","-⊃", "¬>","~>","->", "¬->","~->","-->", "¬C","~C","-C"] -> NCond
+                                         | r `elem` ["≡","<->","<>","B"] -> Bicond
+                                         | r `elem` [ "¬≡","~≡","-≡", "¬<->","~<->","-<->", "¬<>","~<>","-<>", "¬B","~B","-B"] -> NBicond
+                                         | r `elem` [ "¬¬","~~","--"] -> DoubleNeg
+
+
+instance CoreInference IchikawaJenkinsSLTableaux PurePropLexicon (Form Bool) where
+        corePremisesOf Conj = [SA (phin 1) :+: SA (phin 2) :+: GammaV 1 :|-: Bot]
+        corePremisesOf NConj = [ SA (lneg $ phin 1) :+: GammaV 1 :|-: Bot
+                               , SA (lneg $ phin 2) :+: GammaV 2 :|-: Bot
+                               ]
+        corePremisesOf Disj = [ SA (phin 1) :+: GammaV 1 :|-: Bot
+                              , SA (phin 2) :+: GammaV 2 :|-: Bot
+                              ]
+        corePremisesOf NDisj = [SA (lneg $ phin 1) :+: SA (lneg $ phin 2) :+: GammaV 1 :|-: Bot]
+        corePremisesOf Cond = [ SA (lneg $ phin 1) :+: GammaV 1 :|-: Bot
+                              , SA (phin 2) :+: GammaV 2 :|-: Bot
+                              ]
+        corePremisesOf NCond = [SA (phin 1) :+: SA (lneg $ phin 2) :+: GammaV 1 :|-: Bot]
+        corePremisesOf Bicond = [ SA (phin 1) :+: SA (phin 2) :+: GammaV 1 :|-: Bot
+                                , SA (lneg $ phin 1) :+: SA (lneg $ phin 2) :+: GammaV 2 :|-: Bot
+                                ]
+        corePremisesOf NBicond = [ SA (phin 1) :+: SA (lneg $ phin 2) :+: GammaV 1 :|-: Bot
+                                 , SA (lneg $ phin 1) :+: SA (phin 2) :+: GammaV 2 :|-: Bot
+                                 ]
+        corePremisesOf DoubleNeg = [ SA (phin 1)  :+: GammaV 1 :|-: Bot ]
+
+        coreConclusionOf Conj = SA (phin 1 ./\. phin 2) :+: GammaV 1 :|-: Bot
+        coreConclusionOf NConj = SA (lneg $ phin 1 ./\. phin 2 ) :+: GammaV 1 :+: GammaV 2 :|-: Bot
+        coreConclusionOf Disj = SA (phin 1 .\/. phin 2) :+: GammaV 1 :+: GammaV 2 :|-: Bot
+        coreConclusionOf NDisj = SA (lneg $ phin 1 .\/. phin 2) :+: GammaV 1 :|-: Bot
+        coreConclusionOf Cond = SA (phin 1 .=>. phin 2) :+: GammaV 1 :+: GammaV 2 :|-: Bot
+        coreConclusionOf NCond = SA (lneg $ phin 1 .=>. phin 2) :+: GammaV 1 :+: GammaV 2 :|-: Bot
+        coreConclusionOf Bicond = SA (phin 1 .<=>. phin 2) :+: GammaV 1 :+: GammaV 2 :|-: Bot
+        coreConclusionOf NBicond = SA (lneg $ phin 1 .<=>. phin 2) :+: GammaV 1 :+: GammaV 2 :|-: Bot
+        coreConclusionOf DoubleNeg = SA (lneg $ lneg $ phin 1)  :+: GammaV 1 :|-: Bot

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/IchikawaJenkins.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/IchikawaJenkins.hs
@@ -1,6 +1,6 @@
 {-#LANGUAGE FlexibleContexts, FlexibleInstances, MultiParamTypeClasses #-}
 module Carnap.Languages.PurePropositional.Logic.IchikawaJenkins
-    ( parseIchikawaJenkinsSL, IchikawaJenkinsSL,  ichikawaJenkinsSLCalc) where
+    ( parseIchikawaJenkinsSL, IchikawaJenkinsSL,  ichikawaJenkinsSLCalc, ichkawaJenkinsSLTableauCalc) where
 
 import Data.Map as M (lookup, Map)
 import Text.Parsec

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/IchikawaJenkins.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/IchikawaJenkins.hs
@@ -129,10 +129,11 @@ ichikawaJenkinsSLCalc = mkNDCalc
 --  Semantic Tableaux  --
 -------------------------
 
-data IchikawaJenkinsSLTableaux = Conj | NConj | Disj | NDisj | Cond | NCond | Bicond | NBicond | DoubleNeg
+data IchikawaJenkinsSLTableaux = Ax | Conj | NConj | Disj | NDisj | Cond | NCond | Bicond | NBicond | DoubleNeg
     deriving Eq
 
 instance Show IchikawaJenkinsSLTableaux where
+    show Ax = "Ax"
     show Conj = "&"
     show NConj = "¬&"
     show Disj  = "∨"
@@ -158,9 +159,11 @@ parseIchikawaJenkinsSLTableaux = do r <- choice (map (try . string) ["&","¬&","
                                                                 , "<>", "¬<>","~<>","-<>"
                                                                 , "B", "¬B","~B","-B"
                                                                 , "¬¬","~~","--"
+                                                                , "Ax"
                                                                 ])
                                     return $ case r of
                                        r | r == "&" -> Conj
+                                         | r == "Ax" -> Ax
                                          | r `elem` ["¬&","~&","-&"] -> NConj
                                          | r `elem` ["∨","v","\\/"] -> Disj
                                          | r `elem` [ "¬∨","~∨","-∨", "¬\\/","~\\/","-\\/", "¬v","~v","-v"] -> NDisj
@@ -190,6 +193,7 @@ instance CoreInference IchikawaJenkinsSLTableaux PurePropLexicon (Form Bool) whe
                                  , SA (lneg $ phin 1) :+: SA (phin 2) :+: GammaV 2 :|-: Bot
                                  ]
         corePremisesOf DoubleNeg = [ SA (phin 1)  :+: GammaV 1 :|-: Bot ]
+        corePremisesOf Ax = []
 
         coreConclusionOf Conj = SA (phin 1 ./\. phin 2) :+: GammaV 1 :|-: Bot
         coreConclusionOf NConj = SA (lneg $ phin 1 ./\. phin 2 ) :+: GammaV 1 :+: GammaV 2 :|-: Bot
@@ -200,6 +204,7 @@ instance CoreInference IchikawaJenkinsSLTableaux PurePropLexicon (Form Bool) whe
         coreConclusionOf Bicond = SA (phin 1 .<=>. phin 2) :+: GammaV 1 :+: GammaV 2 :|-: Bot
         coreConclusionOf NBicond = SA (lneg $ phin 1 .<=>. phin 2) :+: GammaV 1 :+: GammaV 2 :|-: Bot
         coreConclusionOf DoubleNeg = SA (lneg $ lneg $ phin 1)  :+: GammaV 1 :|-: Bot
+        coreConclusionOf Ax = SA (phin 1) :+: SA (lneg $ phin 1) :+: GammaV 1 :|-: Bot
 
 ichkawaJenkinsSLTableauCalc = TableauCalc 
     { tbParseForm = purePropFormulaParser magnusOpts

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/IchikawaJenkins.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/IchikawaJenkins.hs
@@ -1,6 +1,6 @@
 {-#LANGUAGE FlexibleContexts, FlexibleInstances, MultiParamTypeClasses #-}
 module Carnap.Languages.PurePropositional.Logic.IchikawaJenkins
-    ( parseIchikawaJenkinsSL, IchikawaJenkinsSL,  ichikawaJenkinsSLCalc, ichkawaJenkinsSLTableauCalc) where
+    ( parseIchikawaJenkinsSL, IchikawaJenkinsSL,  ichikawaJenkinsSLCalc, ichkawaJenkinsSLTableauCalc, IchikawaJenkinsSLTableaux(..), IchikawaJenkinsSL(..)) where
 
 import Data.Map as M (lookup, Map)
 import Text.Parsec

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/Ripley.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/Ripley.hs
@@ -38,7 +38,6 @@ instance Show RipleyLNJ where
         show FalsumElim   = "⊥E"
         show As           = "AS"
 
-
 instance Inference RipleyLNJ PurePropLexicon (Form Bool) where
         ruleOf ConjIntro    = adjunction
         ruleOf ConjElimL    = simplificationVariations !! 0
@@ -53,6 +52,7 @@ instance Inference RipleyLNJ PurePropLexicon (Form Bool) where
         ruleOf As           = axiom        
 
         globalRestriction (Left ded) n CondIntro = Just (dischargeConstraint n ded (view lhs $ conclusionOf CondIntro))
+        globalRestriction (Left ded) n CondIntroVac = Just (dischargeConstraint n ded (view lhs $ conclusionOf CondIntroVac))
         globalRestriction (Left ded) n DisjElim = Just (dischargeConstraint n ded (view lhs $ conclusionOf DisjElim))
         globalRestriction _ _ _ = Nothing
 

--- a/Carnap/src/Carnap/Languages/PurePropositional/Logic/Rules.hs
+++ b/Carnap/src/Carnap/Languages/PurePropositional/Logic/Rules.hs
@@ -44,7 +44,7 @@ premConstraint (Just prems) sub | theinstance `elem` prems = Nothing
     where theinstance = pureBNF . applySub sub $ (SA (phin 1) :|-: SS (phin 1))
           project = view rhs
 
-dischargeConstraint n ded lhs sub | and (map (`elem` forms) lhs') = Nothing
+dischargeConstraint n ded lhs sub | all (`elem` forms) lhs' && all (`elem` lhs') forms = Nothing
                                   | otherwise = Just $ "Some of the stated dependencies in " ++ show forms ++ ", are not among the inferred dependencies " ++ show lhs' ++ "."
     where lhs' = toListOf concretes . applySub sub $ lhs
           scope = inScope (ded !! (n - 1))


### PR DESCRIPTION
This fixes the over-contraction issue, in which a lemmon proof
```
[1] P AS
[2] P AS
[1, 2] P ∧ P (1)(2) ∧I
[1] P → (P ∧ P) [2](3) →I
```
Will be computed to establish `⊢ P → (P ∧ P)` instead of `P ⊢ P → (P ∧ P)`.

It also makes some downstream changes necessitated by the fix, and merges the
sequent calculus work that's now on master into this branch.

Formerly, restrictions on whether a rule is applicable were applied *after* Carnap decided which inference scheme to try. Now, restrictions are used *before*, so that we can use a restriction (roughly the requirement that explicitly in-scope premises in the left column of a lemmon proof must be exactly those that occur in the deduced sequent) to rule out the inference scheme that gives us `⊢ P → (P ∧ P)`, and automatically fall back on one that gives us `P ⊢ P → (P ∧ P)`.